### PR TITLE
Fix two-commit race by moving mutex to HTTP request layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,3 +176,51 @@ end
 ```
 
 A second request for the same kata blocks (sleeps) until the first completes — it does not fail immediately. Read-only routes (`kata_event`, `kata_events`, etc.) are completely unaffected as they do not call `git_ff_merge_worktree`.
+
+---
+
+## Session 3 — closing the two-commit gap in `file_rename` and similar operations
+
+### Diagnosis
+
+Fix 4 (per-call mutex in `git_ff_merge_worktree`) serialises individual git commits but not entire HTTP requests. Some operations call `git_ff_merge_worktree` twice in sequence:
+
+- `file_rename` — calls `file_edit` (1st ff-merge) then the rename commit (2nd ff-merge)
+- `ran_tests`, `predicted_right`, `predicted_wrong`, `reverted`, `checked_out` — all call `file_edit` then `git_commit_tag_sss`
+
+Between the two calls the mutex is released. A competing Puma thread can acquire it, commit at the index the first thread was about to use, and cause the first thread's second commit to raise `'Out of order event'`.
+
+### Reproducing the bug — `test/client/kata_concurrent_saves_test.rb` (DccG02)
+
+`thread_a` calls `kata_ran_tests(id, 1, large_files, ...)`. Its `file_edit` makes a large commit (slow, holding the mutex longer) then releases. `thread_a`'s second ff-merge will try index=2.
+
+100 b_threads each call `kata_ran_tests(id, 2, unique_files_i, ...)` with a unique file edit. Each b_thread's `file_edit` detects its unique change and blocks on the mutex while `thread_a` holds it. When `thread_a` releases after its first commit, one b_thread immediately acquires, commits at index=2, and `thread_a`'s second commit raises `'Out of order event'`.
+
+`kata_ran_tests` is also added to `source/client/external/saver.rb` to make it callable from client tests.
+
+### Fix 5 — Per-request mutex in `app_base.rb` (`post_json_with_mutex`)
+
+The mutex is moved from inside `git_ff_merge_worktree` (per-call) to the HTTP layer (per-request). `app_base.rb` gains:
+
+```ruby
+KATA_MUTEXES_LOCK = Mutex.new
+KATA_MUTEXES = Hash.new { |h, k| h[k] = Mutex.new }
+
+def self.post_json_with_mutex(klass_name, method_name)
+  post "/#{method_name}", provides:[:json] do
+    respond_to do |format|
+      format.json do
+        id = to_json_object(request_body)['id']
+        mutex = AppBase::KATA_MUTEXES_LOCK.synchronize { AppBase::KATA_MUTEXES[id] }
+        mutex.synchronize do
+          json_result(klass_name, method_name)
+        end
+      end
+    end
+  end
+end
+```
+
+All kata state-mutating POST routes in `app.rb` are switched from `post_json` to `post_json_with_mutex`. The mutex is keyed on `id`, so the entire HTTP request — however many `git_ff_merge_worktree` calls it makes — is atomic with respect to other requests for the same kata.
+
+The `REPO_MUTEXES_LOCK`, `REPO_MUTEXES`, and mutex acquisition are removed from `git_ff_merge_worktree` in `kata_v2.rb`, as the per-request mutex supersedes them.

--- a/source/client/external/saver.rb
+++ b/source/client/external/saver.rb
@@ -94,6 +94,13 @@ module External
       @http.post(__method__, { id:id, index:index, files:files })
     end
 
+    def kata_ran_tests(id, index, files, stdout, stderr, status, summary)
+      @http.post(__method__, {
+        id:id, index:index, files:files,
+        stdout:stdout, stderr:stderr, status:status, summary:summary
+      })
+    end
+
     # - - - - - - - - - - - - - - - - - -
 
     def kata_option_get(id, name)

--- a/source/server/app.rb
+++ b/source/server/app.rb
@@ -19,7 +19,7 @@ class App < AppBase
    get_json(:model, :group_joined)
   post_json(:model, :group_fork)
 
-   # - - - - - - - - - - - - - - - - -
+  # - - - - - - - - - - - - - - - - -
 
   post_json(:model, :kata_create)
    get_json(:model, :kata_download)
@@ -29,19 +29,20 @@ class App < AppBase
    get_json(:model, :kata_manifest)
   post_json(:model, :kata_fork)
    get_json(:model, :katas_events)
-
-  post_json(:model, :kata_file_create)
-  post_json(:model, :kata_file_delete)
-  post_json(:model, :kata_file_rename)
-  post_json(:model, :kata_file_edit)
-  
-  post_json(:model, :kata_ran_tests)
-  post_json(:model, :kata_predicted_right)
-  post_json(:model, :kata_predicted_wrong)
-  post_json(:model, :kata_reverted)
-  post_json(:model, :kata_checked_out)
-
    get_json(:model, :kata_option_get)
-  post_json(:model, :kata_option_set)
+
+  # - - - - - - - - - - - - - - - - -
+
+  post_json_with_mutex(:model, :kata_file_create)
+  post_json_with_mutex(:model, :kata_file_delete)
+  post_json_with_mutex(:model, :kata_file_rename)
+  post_json_with_mutex(:model, :kata_file_edit)
+
+  post_json_with_mutex(:model, :kata_ran_tests)
+  post_json_with_mutex(:model, :kata_predicted_right)
+  post_json_with_mutex(:model, :kata_predicted_wrong)
+  post_json_with_mutex(:model, :kata_reverted)
+  post_json_with_mutex(:model, :kata_checked_out)
+  post_json_with_mutex(:model, :kata_option_set)
 
 end

--- a/source/server/app_base.rb
+++ b/source/server/app_base.rb
@@ -41,6 +41,42 @@ class AppBase < Sinatra::Base
     end
   end
 
+  # - - - - - - - - - - - - - - - - - - - - - -
+
+  # One Mutex per kata id, serialising all POST requests for the same kata
+  # across Puma threads. This ensures multi-step operations such as
+  # file_rename (which calls git_ff_merge_worktree twice) are atomic:
+  # no competing thread can interleave between the two commits.
+  #
+  # KATA_MUTEXES_LOCK is needed because the GIL can be released between the
+  # "key absent?" check and the default-block assignment in the Hash, allowing
+  # two threads to each create a different Mutex for the same id. Without the
+  # lock they would synchronise on different objects and the race would not be
+  # prevented for that operation.
+  #
+  # Known limitation: entries are never removed, so the hash grows by one
+  # small Mutex object per kata ever seen in this process. Each entry is only
+  # a few dozen bytes; a busy server with tens of thousands of katas would
+  # accumulate only a few MB in total.
+  KATA_MUTEXES_LOCK = Mutex.new
+  KATA_MUTEXES = Hash.new { |h, k| h[k] = Mutex.new }
+
+  def self.post_json_with_mutex(klass_name, method_name)
+    post "/#{method_name}", provides:[:json] do
+      # :nocov:
+      respond_to do |format|
+        format.json do
+          id = to_json_object(request_body)['id']
+          mutex = AppBase::KATA_MUTEXES_LOCK.synchronize { AppBase::KATA_MUTEXES[id] }
+          mutex.synchronize do
+            json_result(klass_name, method_name)
+          end
+        end
+      end
+      # :nocov:
+    end
+  end
+
   private
 
   include JsonAdapter

--- a/source/server/model/kata_v2.rb
+++ b/source/server/model/kata_v2.rb
@@ -445,45 +445,26 @@ class Kata_v2
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  # One Mutex per kata repo, keyed on repo_dir, serialising all
-  # git_ff_merge_worktree calls for the same kata across Puma threads.
-  #
-  # REPO_MUTEXES_LOCK is needed. The Global VM Lock (GIL) can be released
-  # between the "key absent?" check and the default-block assignment,
-  # allowing two threads to each create a different Mutex for the same
-  # repo_dir. Without the lock they would synchronise on different objects
-  # and the race would not be prevented for that operation.
-  #
-  # Known limitation: entries are never removed, so the hash grows by one
-  # small Mutex object per kata ever seen in this process. Each entry is only
-  # a few dozen bytes; a busy server with tens of thousands of katas would
-  # accumulate only a few MB in total.
-  REPO_MUTEXES_LOCK = Mutex.new
-  REPO_MUTEXES = Hash.new { |h, k| h[k] = Mutex.new }
-
   def git_ff_merge_worktree(repo_dir)
-    mutex = REPO_MUTEXES_LOCK.synchronize { REPO_MUTEXES[repo_dir] }
-    mutex.synchronize do
-      branch = random.alphanumeric(8)
-      worktree_dir = "/tmp/#{branch}"
+    branch = random.alphanumeric(8)
+    worktree_dir = "/tmp/#{branch}"
+    begin
+      shell.assert_cd_exec(repo_dir, "git worktree add #{worktree_dir}")
+      worktree = External::Disk.new(worktree_dir)
+      yield worktree
+      shell.assert_cd_exec(repo_dir, "git merge --ff-only #{branch}")
+    ensure
       begin
-        shell.assert_cd_exec(repo_dir, "git worktree add #{worktree_dir}")
-        worktree = External::Disk.new(worktree_dir)
-        yield worktree
-        shell.assert_cd_exec(repo_dir, "git merge --ff-only #{branch}")
-      ensure
-        begin
-          shell.assert_cd_exec(repo_dir,
-            "git worktree remove --force #{branch}",
-            "git branch --delete --force #{branch}",
-            "rm -rf #{worktree_dir}"
-          )
-        rescue => e
-          # :nocov:
-          $stderr.puts "git_ff_merge_worktree cleanup failed: #{e.message}"
-          $stderr.flush
-          # :nocov:
-        end
+        shell.assert_cd_exec(repo_dir,
+          "git worktree remove --force #{branch}",
+          "git branch --delete --force #{branch}",
+          "rm -rf #{worktree_dir}"
+        )
+      rescue => e
+        # :nocov:
+        $stderr.puts "git_ff_merge_worktree cleanup failed: #{e.message}"
+        $stderr.flush
+        # :nocov:
       end
     end
   end

--- a/test/client/config/coverage_metrics_limits.rb
+++ b/test/client/config/coverage_metrics_limits.rb
@@ -2,12 +2,12 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 791 ],
+    [ 'test.lines.total'    , '<=', 810 ],
     [ 'test.lines.missed'   , '<=', 0   ],
     [ 'test.branches.total' , '<=', 2   ],
     [ 'test.branches.missed', '<=', 0   ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 136 ],
+    [ 'code.lines.total'    , '<=', 138 ],
     [ 'code.lines.missed'   , '<=', 0   ],
     [ 'code.branches.total' , '<=', 2   ],
     [ 'code.branches.missed', '<=', 0   ],

--- a/test/client/kata_concurrent_saves_test.rb
+++ b/test/client/kata_concurrent_saves_test.rb
@@ -30,4 +30,66 @@ class KataConcurrentSavesTest < TestBase
     end
   end
 
+  version_test 2, 'DccG02', %w(
+  | kata_ran_tests does not raise 'Out of order event' for its second
+  | git_ff_merge_worktree call when a concurrent kata_ran_tests intervenes.
+  |
+  | kata_ran_tests calls git_ff_merge_worktree twice:
+  |   1st call: via file_edit - commits the large file edit (slow)
+  |   2nd call: commits the test run at index=2
+  |
+  | Each b_thread calls kata_ran_tests at index=2 with a unique file edit.
+  | Each b_thread's file_edit detects its unique edit and blocks on the
+  | per-call mutex while thread_a holds it for its slow 1st commit.
+  | When thread_a releases, one b_thread immediately acquires, commits at
+  | index=2, and thread_a's 2nd commit raises 'Out of order event'.
+  | 100 b_threads ensure at least one is queued on the mutex when thread_a
+  | releases, making the race reliable.
+  |
+  | After applying post_json_with_mutex, thread_a holds the mutex for its
+  | entire HTTP request (both commits are atomic), so no b_thread can
+  | intervene and thread_a succeeds.
+  ) do
+    in_kata do |id|
+      files = kata_event(id, 0)['files']
+      stdout  = { 'content' => '', 'truncated' => false }
+      stderr  = { 'content' => '', 'truncated' => false }
+      status  = 0
+      summary = { 'colour' => 'red', 'predicted' => 'none' }
+
+      # thread_a uses a large edit so its first git_ff_merge_worktree is slow,
+      # giving b_threads time to queue up on the mutex.
+      large_files = files.merge('tennis.py' => { 'content' => 'x' * 100_000 })
+
+      # Each b_thread gets a unique edit so its file_edit always detects a
+      # change and calls git_ff_merge_worktree, queuing on the mutex.
+      b_files = 100.times.map do |i|
+        files.merge('tennis.py' => { 'content' => 'x' * 100_000 + i.to_s })
+      end
+
+      errors = []
+      errors_mutex = Mutex.new
+
+      thread_a = Thread.new do
+        saver.kata_ran_tests(id, 1, large_files, stdout, stderr, status, summary)
+      rescue => error
+        # :nocov:
+        errors_mutex.synchronize { errors << error.message }
+        # :nocov:
+      end
+
+      b_threads = b_files.map do |bf|
+        Thread.new do
+          saver.kata_ran_tests(id, 2, bf, stdout, stderr, status, summary)
+        rescue
+          # Each b_thread's own success or failure is irrelevant;
+          # only thread_a's outcome matters.
+        end
+      end
+
+      ([thread_a] + b_threads).each(&:join)
+      assert_empty errors
+    end
+  end
+
 end


### PR DESCRIPTION
Operations such as kata_ran_tests and kata_file_rename call git_ff_merge_worktree twice per request (once via file_edit, once for the main commit). The per-call mutex from Fix 4 serialised individual commits but released between the two calls, allowing a competing Puma thread to commit at the index the first thread was about to use, raising 'Out of order event' on the second commit.

The fix moves the mutex from git_ff_merge_worktree up to the HTTP layer via post_json_with_mutex in app_base.rb, keyed on the kata id. The entire request now holds the mutex, making both commits atomic.

Test DccG02 reproduces the race: thread_a calls kata_ran_tests with a large file edit (slow first commit); 100 b_threads concurrently call kata_ran_tests at index=2 with unique edits, queuing on the mutex. One b_thread steals index=2 before thread_a's second commit, confirming the bug without the fix and passing cleanly with it.