### PR TITLE
Add new-snyk-scan job to CI workflow

### DIFF
--- a/.github/workflows/force-ci-run
+++ b/.github/workflows/force-ci-run
@@ -1,2 +1,2 @@
 Edit this file for a quick way to force a CI run
-185
+186

--- a/.github/workflows/force-ci-run
+++ b/.github/workflows/force-ci-run
@@ -1,2 +1,2 @@
 Edit this file for a quick way to force a CI run
-184
+185

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
 
   new-snyk-scan:
     needs: [build-image]
-    uses: cyber-dojo/live-snyk-scans/.github/workflows/artifact_snyk_test.yml@main
+    uses: cyber-dojo/snyk-scanning/.github/workflows/artifact_snyk_test.yml@main
     with:
       artifact_name:        ${{ needs.build-image.outputs.tagged_image_name }}
       artifact_fingerprint: ${{ needs.build-image.outputs.digest }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,6 @@ jobs:
       commit_url:           https://github.com/${{ github.repository }}/commit/${{ github.sha }}
       raw_snyk_policy_url:  https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/.snyk
       kosli_flow:           snyk-vulns-build
-      kosli_cat:            single-snyk-vuln
     secrets:
       snyk_token:      ${{ secrets.SNYK_TOKEN }}
       kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,6 +134,7 @@ jobs:
     needs: [build-image]
     uses: cyber-dojo/snyk-scanning/.github/workflows/artifact_snyk_test.yml@main
     with:
+      aws_rolename:         gh_actions_services
       artifact_name:        ${{ needs.build-image.outputs.tagged_image_name }}
       artifact_fingerprint: ${{ needs.build-image.outputs.digest }}
       repo_name:            ${{ github.event.repository.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,6 +130,23 @@ jobs:
           attestation_name:  saver.snyk-container-scan
 
 
+  new-snyk-scan:
+    needs: [build-image]
+    uses: cyber-dojo/live-snyk-scans/.github/workflows/artifact_snyk_test.yml@main
+    with:
+      artifact_name:        ${{ needs.build-image.outputs.tagged_image_name }}
+      artifact_fingerprint: ${{ needs.build-image.outputs.digest }}
+      repo_name:            ${{ github.event.repository.name }}
+      git_commit:           ${{ github.sha }}
+      commit_url:           https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+      raw_snyk_policy_url:  https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/.snyk
+      kosli_flow:           snyk-vulns-build
+      kosli_cat:            single-snyk-vuln
+    secrets:
+      snyk_token:      ${{ secrets.SNYK_TOKEN }}
+      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
+
+
   unit-tests:
     runs-on: ubuntu-latest
     needs: [build-image]
@@ -243,6 +260,7 @@ jobs:
       - unit-tests
       - integration-tests
       - snyk-container-scan
+      - new-snyk-scan
     env:
       KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM ghcr.io/cyber-dojo/sinatra-base:a2408d5@sha256:d0d4d7f9c44500a5fae8275e777658ac9d2b09ea44e0313a4a56d698437da3e7
-# FROM ghcr.io/cyber-dojo/sinatra-base:1b1df8e@sha256:0cf1c46e55c2c66cb7c55724f405784364be1d18cb7a2f47f6f0abf1cee0a80d
+FROM ghcr.io/cyber-dojo/sinatra-base:1b1df8e@sha256:0cf1c46e55c2c66cb7c55724f405784364be1d18cb7a2f47f6f0abf1cee0a80d
 # The FROM statement above is typically set via an automated pull-request from the sinatra-base repo
 LABEL maintainer=jon@jaggersoft.com
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/cyber-dojo/sinatra-base:1b1df8e@sha256:0cf1c46e55c2c66cb7c55724f405784364be1d18cb7a2f47f6f0abf1cee0a80d
+FROM ghcr.io/cyber-dojo/sinatra-base:a2408d5@sha256:d0d4d7f9c44500a5fae8275e777658ac9d2b09ea44e0313a4a56d698437da3e7
+# FROM ghcr.io/cyber-dojo/sinatra-base:1b1df8e@sha256:0cf1c46e55c2c66cb7c55724f405784364be1d18cb7a2f47f6f0abf1cee0a80d
 # The FROM statement above is typically set via an automated pull-request from the sinatra-base repo
 LABEL maintainer=jon@jaggersoft.com
 


### PR DESCRIPTION
Calls cyber-dojo/live-snyk-scans reusable workflow to run a Snyk artifact scan. Wired into sdlc-control-gate's needs so the gate waits for it before deploying.