### PR TITLE
Improve disk error logging: include command and errno in exception me…

### DIFF
--- a/source/server/disk_api.rb
+++ b/source/server/disk_api.rb
@@ -37,11 +37,14 @@ module DiskApi
     if result
       result
     else
-      raise "command != true"
+      msg = "command != true: #{command.inspect}"
+      msg += " (#{@last_error})" if @last_error
+      raise msg
     end
   end
 
   def run(command)
+    @last_error = nil
     assert_well_formed_command(command)
     name, *args = command
     {
@@ -62,7 +65,9 @@ module DiskApi
       if r
         false
       else
-        raise "commands[#{index}] != true"
+        msg = "commands[#{index}] != true: #{commands[index].inspect}"
+        msg += " (#{@last_error})" if @last_error
+        raise msg
       end
     end
   end

--- a/source/server/external/disk.rb
+++ b/source/server/external/disk.rb
@@ -28,7 +28,7 @@ module External
       #   -p creates intermediate dirs as required.
       #   -v verbose mode, output each dir actually made
       command = "mkdir -vp '#{path_name(dirname)}'"
-      stdout,stderr,r = Open3.capture3(command)
+      stdout, stderr, r = Open3.capture3(command)
       status = r.exitstatus
       stdout != '' && stderr == '' && status == 0
     end
@@ -44,7 +44,8 @@ module External
       end
       true
     rescue Errno::ENOENT, # dir does not exist
-           Errno::EEXIST  # file already exists
+           Errno::EEXIST => e # file already exists
+      @last_error = e
       false
     end
 
@@ -59,7 +60,8 @@ module External
         fd.write(content)
       end
       true
-    rescue Errno::ENOENT # dir does not exist
+    rescue Errno::ENOENT => e # dir does not exist
+      @last_error = e
       false
     end
 
@@ -75,7 +77,8 @@ module External
       end
       true
     rescue Errno::EISDIR, # file is a dir!
-           Errno::ENOENT  # file does not exist
+           Errno::ENOENT => e # file does not exist
+      @last_error = e
       false
     end
 
@@ -88,7 +91,8 @@ module External
         fd.read
       end
     rescue Errno::EISDIR, # file is a dir!,
-           Errno::ENOENT  # file does not exist
+           Errno::ENOENT => e # file does not exist
+      @last_error = e
       false
     end
 

--- a/test/server/config/coverage_metrics_limits.rb
+++ b/test/server/config/coverage_metrics_limits.rb
@@ -2,14 +2,14 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 2356 ],
+    [ 'test.lines.total'    , '<=', 2378 ],
     [ 'test.lines.missed'   , '<=', 0    ],
-    [ 'test.branches.total' , '<=', 14   ],
+    [ 'test.branches.total' , '<=', 18   ],
     [ 'test.branches.missed', '<=', 0    ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 1401 ],
+    [ 'code.lines.total'    , '<=', 1410 ],
     [ 'code.lines.missed'   , '<=', 0    ],
-    [ 'code.branches.total' , '<=', 163  ],
+    [ 'code.branches.total' , '<=', 167  ],
     [ 'code.branches.missed', '<=', 0    ],
   ]
 end

--- a/test/server/config/test_metrics_limits.rb
+++ b/test/server/config/test_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test_count',    '>=', 359 ],
+    [ 'test_count',    '>=', 363 ],
     [ 'total_time',    '<=', 100 ],
     [ nil ],
     [ 'failure_count', '<=', 0   ],

--- a/test/server/disk_assert.rb
+++ b/test/server/disk_assert.rb
@@ -16,7 +16,7 @@ class DiskAssertTest < TestBase
     error = assert_raises(RuntimeError) {
       disk.assert(dir_exists_command(dirname))
     }
-    assert_equal 'command != true', error.message
+    assert_equal "command != true: #{dir_exists_command(dirname).inspect}", error.message
     refute disk.run(dir_exists_command(dirname))
   end
 
@@ -31,6 +31,20 @@ class DiskAssertTest < TestBase
     disk.assert(file_create_command(filename, content))
     read = disk.assert(file_read_command(filename))
     assert_equal content, read
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - -
+
+  disk_tests 'FA253A',
+  'assert() raises with command and error when @last_error is set' do
+    dirname = 'groups/Fw/FP/3a'
+    disk.assert(dir_make_command(dirname))
+    filename = dirname + '/3a.events.json'
+    error = assert_raises(RuntimeError) {
+      disk.assert(file_read_command(filename))
+    }
+    assert_includes error.message, "command != true: #{file_read_command(filename).inspect}"
+    assert_includes error.message, 'No such file or directory'
   end
 
   # - - - - - - - - - - - - - - - - - - - - -

--- a/test/server/disk_assert_all.rb
+++ b/test/server/disk_assert_all.rb
@@ -45,8 +45,25 @@ class DiskAssertAllTest < TestBase
     error = assert_raises(RuntimeError) {
       disk.assert_all(@commands)
     }
-    assert_equal "commands[3] != true", error.message
+    assert_includes error.message, "commands[3] != true: #{@commands[3].inspect}"
+    assert_includes error.message, 'No such file or directory'
     assert_equal content, disk.run(file_read_command(there_yes)), :does_not_execute_subsequent_commands
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  disk_tests '21C418', %w(
+  assert_all() raises
+  with command but no error
+  when failing command does not set last_error
+  ) do
+    dirname = 'server/assert-all/e3/t4/18'
+    command(true, dir_make_command(dirname))
+    command(false, dir_exists_command('server/assert-all/e3/t4/18/no-subdir'))
+    error = assert_raises(RuntimeError) {
+      disk.assert_all(@commands)
+    }
+    assert_equal "commands[1] != true: #{@commands[1].inspect}", error.message
   end
 
   private

--- a/test/server/doubles/disk_fake.rb
+++ b/test/server/doubles/disk_fake.rb
@@ -24,6 +24,7 @@ class DiskFake
       files[path] = value
       true
     else
+      @last_error = file?(path) ? "File exists - #{path}" : "No such file or directory - #{path}"
       false
     end
   end
@@ -34,6 +35,7 @@ class DiskFake
       files[path] = value
       true
     else
+      @last_error = "No such file or directory - #{path}"
       false
     end
   end
@@ -44,12 +46,16 @@ class DiskFake
       files[path] += value
       true
     else
+      @last_error = "No such file or directory - #{path}"
       false
     end
   end
 
   def file_read(key)
-    files[path_name(key)] || false
+    path = path_name(key)
+    result = files[path]
+    @last_error = "No such file or directory - #{path}" unless result
+    result || false
   end
 
   # - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
…ssage

When a disk assertion fails, the logged exception previously said only "command != true", giving no clue which command failed or why. Now it includes the command array and, where available, the underlying errno (e.g. Errno::ENOENT) so that errors like the group_joined failure in the dashboard log are immediately actionable.

DiskFake mirrors the same @last_error contract so fake-disk tests exercise the same code paths as real-disk tests.