### PR TITLE
Avoid per-request flock overhead by detecting concurrent writes at th…

### DIFF
--- a/source/server/app.rb
+++ b/source/server/app.rb
@@ -12,14 +12,19 @@ class App < AppBase
 
   # - - - - - - - - - - - - - - - - -
 
+   get_json(:model, :diff_lines)
+   get_json(:model, :diff_summary)
+
+  # - - - - - - - - - - - - - - - - -
+
   post_json(:model, :group_create)
    get_json(:model, :group_exists?)
    get_json(:model, :group_manifest)
   post_json(:model, :group_join)
    get_json(:model, :group_joined)
-  post_json(:model, :group_fork, lock: false)
 
-  # - - - - - - - - - - - - - - - - -
+  post_json(:model, :group_fork)
+  post_json(:model, :kata_fork)
 
   post_json(:model, :kata_create)
    get_json(:model, :kata_download)
@@ -27,13 +32,8 @@ class App < AppBase
    get_json(:model, :kata_events)
    get_json(:model, :kata_event)
    get_json(:model, :kata_manifest)
-  post_json(:model, :kata_fork, lock: false)
    get_json(:model, :katas_events)
    get_json(:model, :kata_option_get)
-   get_json(:model, :diff_lines)
-   get_json(:model, :diff_summary)
-
-  # - - - - - - - - - - - - - - - - -
 
   post_json(:model, :kata_file_create)
   post_json(:model, :kata_file_delete)

--- a/source/server/app_base.rb
+++ b/source/server/app_base.rb
@@ -1,4 +1,3 @@
-require 'fileutils'
 require_relative 'silently'
 require 'sinatra/base'
 silently { require 'sinatra/contrib' } # N x "warning: method redefined"
@@ -35,16 +34,12 @@ class AppBase < Sinatra::Base
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def self.post_json(klass_name, method_name, lock: true)
+  def self.post_json(klass_name, method_name)
     post "/#{method_name}", provides:[:json] do
       respond_to do |format|
         format.json do
           args = to_json_object(request_body)
-          if lock
-            json_with_flock(args) { json_result(klass_name, method_name, args) }
-          else
-            json_result(klass_name, method_name, args)
-          end
+          json_result(klass_name, method_name, args)
         end
       end
     end
@@ -54,28 +49,6 @@ class AppBase < Sinatra::Base
 
   include JsonAdapter
   include Utf8
-
-  def json_with_flock(args)
-    # Serialise all requests for the same kata/group id across both Puma
-    # threads and Puma worker processes. An OS-level flock(LOCK_EX) is used
-    # so the lock is visible to every worker process, unlike a Ruby Mutex
-    # which is in-process only. When id is absent or not a String (e.g.
-    # kata_create, group_create, or a malformed id) no lock is needed.
-    id = args['id']
-    unless id.is_a?(String) && id.length >= 6
-      yield
-    else
-      root = @externals.disk.root_dir
-      lock_dir = File.join('', root, 'locks', id[0..1], id[2..3])
-      FileUtils.mkdir_p(lock_dir)
-      File.open(File.join(lock_dir, "#{id[4..5]}.lock"), File::RDWR | File::CREAT, 0600) do |f|
-        unless f.flock(File::LOCK_EX | File::LOCK_NB)
-          raise "Out of order event for #{id}"
-        end
-        yield
-      end
-    end
-  end
 
   def json_result(klass_name, method_name, args)
     named_args = Hash[args.map{ |key,value| [key.to_sym, value] }]

--- a/source/server/config/puma.rb
+++ b/source/server/config/puma.rb
@@ -5,27 +5,17 @@ require 'etc'
 environment 'production'
 rackup "#{__dir__}/config.ru"
 
-# POST requests are serialised per kata/group id via json_with_flock
-# (app_base.rb), which holds an OS-level flock(LOCK_EX) on a per-id lock
-# file for the entire duration of each request. This prevents two concurrent
-# writes to the same kata from interleaving (e.g. two kata_ran_tests calls
-# whose git_ff_merge_worktree sequences would otherwise overlap and cause an
-# 'Out of order event' error).
+# Each POST write happens inside a git worktree and is merged back to the
+# main branch via git merge --ff-only (kata_v2.rb). If two concurrent writes
+# target the same kata, only one fast-forward merge will succeed; the other
+# fails and is detected as an 'Out of order event' error, which the web layer
+# treats as an out-of-sync condition and shows a dialog.
 #
-# GET requests do not acquire the lock: all writes happen inside a git
-# worktree and are merged back via an atomic git fast-forward, so a
-# concurrent read always sees a consistent committed state.
+# GET requests always see a consistent committed state because all writes are
+# atomic at the git level.
 #
-# The lock is non-blocking (LOCK_EX | LOCK_NB): if a request cannot
-# immediately acquire the lock it raises "Out of order event", which
-# the web layer treats as an out-of-sync condition and shows a dialog.
-#
-# Because flock is an OS-level primitive, the lock is shared across all Puma
-# worker processes: whichever worker holds the lock for a given id, every
-# other worker trying to acquire the same lock will block until it is released.
-# Different kata ids lock on different files and are therefore independent.
-#
-# The test KataConcurrentSavesTest#DccG02 reproduces the race reliably and
-# confirms it does not occur with flock locking in place.
+# The test KataConcurrentSavesTest#DccG02 reproduces the concurrent-write
+# race and confirms exactly one save succeeds while the rest raise
+# 'Out of order event'.
 
 workers Etc.nprocessors

--- a/source/server/model/kata_v2.rb
+++ b/source/server/model/kata_v2.rb
@@ -373,9 +373,39 @@ class Kata_v2
   end
   
   def git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message)
+    all_events = worktree_commit(id, index, files, stdout, stderr, status, summary, tag_message)
+    shell.assert_cd_exec(repo_dir(id), ["git tag #{index} HEAD"])
+
+    { 
+      'next_index' => index + 1, 
+      'major_index' => major_index(all_events, index),
+      'minor_index' => 0
+    }
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - -
+
+  def worktree_commit(id, index, files, stdout, stderr, status, summary, tag_message)
+    # Out-of-sync detection has two layers, each catching a different scenario.
+    #
+    # 1. Sequential stale index (inside the worktree block):
+    #    The client sends an index that is behind the current last_index, but
+    #    there is no concurrent request. Without the explicit check, the worktree
+    #    commit and the git merge --ff-only would both SUCCEED, silently writing
+    #    corrupt data (e.g. two events.json entries with the same index). The
+    #    unless check catches this before any git work is done.
+    #
+    # 2. Concurrent write (rescue block):
+    #    Two requests for the same kata arrive simultaneously. Both create their
+    #    worktrees from the same HEAD, both pass the index check (they both see
+    #    the same last_index), and both commit to their respective worktree
+    #    branches. Whichever request reaches git merge --ff-only second will fail
+    #    because HEAD has already moved forward. The rescue detects this by
+    #    re-reading events.json from the main repo: if last_index >= index, a
+    #    concurrent write succeeded first, so "Out of order event" is raised.
+    #    Any other failure (e.g. disk error) is re-raised as-is.
     all_events = nil
     git_ff_merge_worktree(repo_dir(id)) do |worktree|
-      # Update events in worktree
       all_events = read_events(worktree)
       last_index = all_events.last['index']
 
@@ -401,19 +431,19 @@ class Kata_v2
       regex1 = /\d+ files? changed, (\d+) insertions?\(\+\), (\d+) deletion/
       regex2 = /\d+ files? changed, (\d+) insertions?\(\+\)/
       regex3 = /\d+ files? changed, (\d+) deletions?\(\-\)/
-      if m = info.match(regex1) 
+      if m = info.match(regex1)
         added_count, deleted_count = *m.captures
       elsif m = info.match(regex2)
         added_count, deleted_count = *m.captures, 0
       elsif m = info.match(regex3)
         added_count, deleted_count = 0, *m.captures
-      else 
+      else
         added_count, deleted_count = 0, 0
       end
 
       # Write the new event
-      all_events << summary.merge!({ 
-        'index' => index, 
+      all_events << summary.merge!({
+        'index' => index,
         'time' => time.now,
         'diff_added_count' => added_count.to_i,
         'diff_deleted_count' => deleted_count.to_i
@@ -437,15 +467,13 @@ class Kata_v2
       # Commit
       shell.assert_cd_exec(worktree.root_dir, "git commit --message '#{index} #{tag_message}' --quiet")
     end
-
-    # git_ff_merge_worktree succeeded, so tag
-    shell.assert_cd_exec(repo_dir(id), ["git tag #{index} HEAD"])
-
-    { 
-      'next_index' => index + 1, 
-      'major_index' => major_index(all_events, index),
-      'minor_index' => 0
-    }
+    all_events
+  rescue
+    current_events = read_events(disk, id)
+    if current_events.last['index'] >= index
+      raise "Out of order event for #{id}"
+    end
+    raise
   end
 
   # - - - - - - - - - - - - - - - - - - - - - -

--- a/test/client/kata_concurrent_saves_test.rb
+++ b/test/client/kata_concurrent_saves_test.rb
@@ -4,11 +4,10 @@ class KataConcurrentSavesTest < TestBase
 
   version_test 2, 'DccG02', %w(
   | N concurrent kata_ran_tests calls to the same kata-id all use index=1.
-  | Exactly one succeeds (whichever acquires the non-blocking flock first).
-  | The remaining N-1 all get 'Out of order event': either immediately from
-  | the flock, or from the index check (1 != last_index+1 once index=1 is
-  | taken). Even sequential execution cannot produce more than one success
-  | since all threads hardcode index=1.
+  | Exactly one succeeds. The remaining N-1 all get 'Out of order event':
+  | either from the index check (sequential case) or from the failed
+  | git merge --ff-only (concurrent case). Even sequential execution cannot
+  | produce more than one success since all threads hardcode index=1.
   ) do
     n = 10
     in_kata do |id|

--- a/test/server/config/coverage_metrics_limits.rb
+++ b/test/server/config/coverage_metrics_limits.rb
@@ -2,14 +2,14 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 2748 ],
+    [ 'test.lines.total'    , '<=', 2745 ],
     [ 'test.lines.missed'   , '<=', 0    ],
-    [ 'test.branches.total' , '<=', 2    ],
+    [ 'test.branches.total' , '<=', 4    ],
     [ 'test.branches.missed', '<=', 0    ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 1513 ],
+    [ 'code.lines.total'    , '<=', 1506 ],
     [ 'code.lines.missed'   , '<=', 0    ],
-    [ 'code.branches.total' , '<=', 221  ],
+    [ 'code.branches.total' , '<=', 217  ],
     [ 'code.branches.missed', '<=', 0    ],
   ]
 end

--- a/test/server/config/test_metrics_limits.rb
+++ b/test/server/config/test_metrics_limits.rb
@@ -2,8 +2,8 @@
 def metrics
   [
     [ nil ],
-    [ 'test_count',    '>=', 340 ],
-    [ 'total_time',    '<=', 100 ],
+    [ 'test_count',    '>=', 338 ],
+    [ 'total_time',    '<=',  50 ],
     [ nil ],
     [ 'failure_count', '<=', 0   ],
     [ 'error_count'  , '<=', 0   ],

--- a/test/server/kata_ran_tests.rb
+++ b/test/server/kata_ran_tests.rb
@@ -43,6 +43,43 @@ class KataRanTestsTest < TestBase
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+  version_test 2, 'Sp4DkC', %w(
+  | a non-out-of-sync failure inside the worktree block
+  | (e.g. git commit failing) is re-raised as-is,
+  | not converted to "Out of order event"
+  ) do
+    gid = group_create(custom_manifest)
+    id  = group_join(gid)
+    files  = kata_event(id, 0)['files']
+    stdout = { 'content' => '', 'truncated' => false }
+    stderr = { 'content' => '', 'truncated' => false }
+    status = 0
+
+    error_shell = Class.new do
+      def initialize(real)
+        @real = real
+      end
+      def assert_cd_exec(path, *commands)
+        if commands.flatten.any? { |c| c.to_s.start_with?('git commit') }
+          raise RuntimeError, 'simulated git commit failure'
+        end
+        @real.assert_cd_exec(path, *commands)
+      end
+      def cd_exec(path, command)
+        @real.cd_exec(path, command)
+      end
+    end.new(shell)
+
+    externals.instance_variable_set('@shell', error_shell)
+
+    error = assert_raises(RuntimeError) {
+      kata_ran_tests(id, 1, files, stdout, stderr, status, red_summary)
+    }
+    assert_equal 'simulated git commit failure', error.message
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
   version_test 0, 'Sp4DkA', %w(
   | kata_ran_tests raises NoLongerImplementedError
   | on v0 katas

--- a/test/server/rack_dispatching.rb
+++ b/test/server/rack_dispatching.rb
@@ -42,48 +42,6 @@ class RackDispatchingTest < TestBase
     assert_get('kata_exists?id=5rTJv5', '', 'kata_exists?', true)
   end
 
-  test 'FF0E43', %w(
-  | post_json dispatches through json_with_flock
-  | when id is absent (kata_create) the lock is skipped
-  | when id is present (kata_option_set) the lock is acquired
-  ) do
-    manifest = manifest_Tennis_refactoring_Python_unitttest.merge('version' => 2)
-    response = post_json('/kata_create', { 'manifest' => manifest }.to_json)
-    assert_equal 200, response.status
-    id = JSON.parse(response.body)['kata_create']
-    response = post_json('/kata_option_set', { 'id' => id, 'name' => 'theme', 'value' => 'dark' }.to_json)
-    assert_equal 200, response.status
-  end
-
-  test 'FF0E44', %w(
-  | post_json dispatches without flock for kata_fork
-  | covering the lock: false branch in app_base
-  ) do
-    manifest = manifest_Tennis_refactoring_Python_unitttest.merge('version' => 2)
-    response = post_json('/kata_create', { 'manifest' => manifest }.to_json)
-    assert_equal 200, response.status
-    id = JSON.parse(response.body)['kata_create']
-    response = post_json('/kata_fork', { 'id' => id, 'index' => 0 }.to_json)
-    assert_equal 200, response.status
-  end
-
-  test 'FF0E45', %w(
-  | json_with_flock raises when lock is already held
-  | covering the out-of-order event branch in app_base
-  ) do
-    @version = 2
-    in_kata do |id|
-      saver_app = App.allocate
-      saver_app.instance_variable_set(:@externals, externals)
-      saver_app.send(:json_with_flock, { 'id' => id }) do
-        error = assert_raises(RuntimeError) do
-          saver_app.send(:json_with_flock, { 'id' => id }) { }
-        end
-        assert_equal "Out of order event for #{id}", error.message
-      end
-    end
-  end
-
   # - - - - - - - - - - - - - - - - - - - - - - - - - -
   # 400
   # - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
…e git layer

The OS-level flock in app_base penalised every POST with three filesystem operations (mkdir_p, file open, flock) to guard against rare concurrent out-of-sync events. The git merge --ff-only in kata_v2 already provides the same protection: only one concurrent write can fast-forward merge. The new rescue in worktree_commit detects the merge failure and raises "Out of order event" when events.json confirms another write succeeded first. Sequential stale-index events are still caught by the existing index check before any git work is done.

Also extracts worktree_commit from git_commit_tag_sss for clarity, and removes flock-specific tests that no longer have code to cover.