### PR TITLE
Tag the build Flow with its target environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,8 @@ jobs:
         uses: cyber-dojo/kosli-begin-trail@main
         with:
           flow_description: "Group/Kata model+persistence"
+          flow_tags: |
+            env=${{ env.KOSLI_AWS_BETA }}
 
 
   pull-request:


### PR DESCRIPTION
  The per-environment trail-compliance policies scope on flow.tags.env, and the
  build Flow deploys to aws-beta. Pass flow_tags to kosli-begin-trail so the Flow
  is tagged with its environment, reusing the existing KOSLI_AWS_BETA var rather
  than hard-wiring the name.

  Requires the flow_tags input added to kosli-begin-trail@main.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>