### PR TITLE
Determine kata version from the .git dir instead of reading manifest.…

### DIFF
--- a/source/server/model.rb
+++ b/source/server/model.rb
@@ -15,7 +15,7 @@ class Model
 
   def group_create(manifest:)
     version = from_manifest(manifest)
-    group(version).create(manifest)
+    GROUPS[version].new(@externals).create(manifest)
   end
 
   def group_exists?(id:)
@@ -53,7 +53,7 @@ class Model
 
   def kata_create(manifest:)
     version = from_manifest(manifest)
-    kata(version).create(manifest)
+    KATAS[version].new(@externals).create(manifest)
   end
 
   def kata_exists?(id:)
@@ -159,27 +159,33 @@ class Model
   include JsonAdapter
 
   def group(id)
-    if id?(id)
-      version = from_path(group_id_path(id, 'manifest.json'))
-    else
-      version = id
-    end
-    GROUPS[version].new(@externals)
+    GROUPS[from_path(group_id_path(id, 'manifest.json'))].new(@externals)
   end
 
   def kata(id)
-    if id?(id)
-      version = from_path(kata_id_path(id, 'manifest.json'))
-    else
-      version = id
-    end
-    KATAS[version].new(@externals)
+    KATAS[kata_version(id)].new(@externals)
   end
 
   def from_path(path)
     content = disk.assert(disk.file_read_command(path))
     manifest = json_parse(content)
     manifest['version'].to_i # nil.to_i == 0
+  end
+
+  # A v2 kata is a git repo; v0/v1 are flat files. A .git stat is cheaper than
+  # from_path's manifest read+parse, on a path hit by every kata operation.
+  # Only v2 uses git, so .git present => v2; otherwise fall back to the legacy
+  # manifest read, which must report v0 or v1 (a v2 without .git is an anomaly).
+  def kata_version(id)
+    if disk.run(disk.dir_exists_command(kata_id_path(id, '.git')))
+      2
+    else
+      version = from_path(kata_id_path(id, 'manifest.json'))
+      unless [0, 1].include?(version)
+        fail "kata #{id} has no .git but manifest version is #{version}"
+      end
+      version
+    end
   end
 
   def from_manifest(manifest)

--- a/test/server/config/coverage_metrics_limits.rb
+++ b/test/server/config/coverage_metrics_limits.rb
@@ -2,12 +2,12 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 2972 ],
+    [ 'test.lines.total'    , '<=', 2987 ],
     [ 'test.lines.missed'   , '<=', 0    ],
     [ 'test.branches.total' , '<=', 8    ],
     [ 'test.branches.missed', '<=', 0    ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 1602 ],
+    [ 'code.lines.total'    , '<=', 1603 ],
     [ 'code.lines.missed'   , '<=', 0    ],
     [ 'code.branches.total' , '<=', 225  ],
     [ 'code.branches.missed', '<=', 0    ],

--- a/test/server/config/test_metrics_limits.rb
+++ b/test/server/config/test_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test_count',    '>=', 362 ],
+    [ 'test_count',    '>=', 364 ],
     [ 'total_time',    '<=',  50 ],
     [ nil ],
     [ 'failure_count', '<=', 0   ],

--- a/test/server/kata_torn_read.rb
+++ b/test/server/kata_torn_read.rb
@@ -1,4 +1,5 @@
 require_relative 'test_base'
+require 'fileutils'
 
 class KataTornReadTest < TestBase
 
@@ -132,6 +133,45 @@ class KataTornReadTest < TestBase
         kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary)
       }
       assert_equal "Out of order event for #{id}", error.message
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  version_test 2, 'Tn6Wb8', %w(
+  | Model#kata determines a v2 kata's version from the presence of its .git
+  | directory, not by reading manifest.json. A kata operation that does not
+  | itself read the manifest (kata_events reads events via git) therefore works
+  | even when the working-tree manifest.json is absent, proving version dispatch
+  | no longer reads it.
+  ) do
+    in_kata do |id|
+      files  = kata_event(id, 0)['files']
+      stdout = { 'content' => '', 'truncated' => false }
+      stderr = { 'content' => '', 'truncated' => false }
+      kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary)
+
+      expected = kata_events(id)
+
+      File.delete(working_tree_path(id, 'manifest.json'))
+
+      assert_equal expected, kata_events(id)
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  version_test 2, 'Tn6Wb9', %w(
+  | kata_version only falls back to reading the manifest when there is no .git
+  | dir, and a v2 kata's manifest reports version 2. So a v2 kata whose .git is
+  | missing (an anomaly, not a real v0/v1) fails loudly rather than being
+  | mis-dispatched as some other version.
+  ) do
+    in_kata do |id|
+      FileUtils.rm_rf(working_tree_path(id, '.git'))
+
+      error = assert_raises(RuntimeError) { kata_events(id) }
+      assert_equal "kata #{id} has no .git but manifest version is 2", error.message
     end
   end
 


### PR DESCRIPTION
…json

  Model#kata dispatched to the right Kata_vN class by reading and JSON-parsing
  manifest.json just to pull the version integer, on every kata operation
  (kata_manifest read it twice: once for dispatch, once for content). Only
  kata_v2 is a git repo; v0/v1 are flat files, and v2 has been the only format
  for years. So a kata's version can be read far more cheaply from the presence
  of its .git dir: kata_version returns 2 when .git exists, otherwise falls back
  to the manifest read and asserts it is v0 or v1 (a v2 without .git is an
  anomaly and fails loudly rather than being mis-dispatched).

  While here, remove the id-vs-version overloading in dispatch. kata/group were
  called both with a real id (to dispatch) and with a bare version integer (at
  create time), so the parameter named id was sometimes a version. The create
  paths now pick the class directly (KATAS[version].new / GROUPS[version].new),
  so kata/group take only real ids and the id?/else branch disappears. group
  dispatch still reads manifest.json, since v2 groups are not git repos.

  Tests: Tn6Wb8 asserts kata_events works with the working-tree manifest.json
  deleted, proving dispatch no longer reads it; Tn6Wb9 asserts a v2 kata whose
  .git is missing fails loudly instead of mis-dispatching.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>