### PR TITLE
Build kata download from committed git state, not the working tree

### DIFF
--- a/docs/reads-via-git.md
+++ b/docs/reads-via-git.md
@@ -1,10 +1,47 @@
 
-Reads via git (make git the sole read path)
-============================================
+Reads via git (read committed state via git, not the working tree)
+==================================================================
 
-A design note, not a description of current behaviour. It records a framing
-that came out of investigating concurrent read/write races in v2 katas, so the
-reasoning is not lost. Nothing here is implemented yet.
+A design note born from investigating concurrent read/write races in v2 katas.
+Parts are now implemented; see "Current status and decisions" below for what is
+done, what was decided against, and what remains. The rest of the note keeps the
+original reasoning.
+
+
+- - - -
+## Current status and decisions
+
+Done:
+- The torn-read fix. events.json, options.json, and the worktree_commit
+  out-of-order rescue now read committed state via `git show HEAD:<file>`
+  instead of the working tree (the A/C/E conversions in the enumeration). The
+  race is fixed and verified.
+- Version dispatch. `Model#kata` derives a v2 kata's version from the presence
+  of its `.git` dir (a cheap stat) instead of reading manifest.json, with a
+  legacy manifest fallback that asserts v0/v1. (`Model#group` is unchanged: v2
+  groups are not git repos.)
+
+Decided against: making the kata repo bare. A bare repo is a different on-disk
+layout, so it would be a de-facto new format (v3) and a population of mixed
+bare/non-bare v2 dirs. We do not want that.
+
+Chosen end-state instead: keep the repo NON-bare, but stop refreshing its
+working tree. Advance `main` with `git update-ref` (compare-and-swap) instead of
+`git merge --ff-only`, so the per-save checkout is skipped and the working tree
+just goes stale. A stale working tree is harmless because the reads that need
+current data already go through git. This is the write speedup, with no bare
+repo and no v3.
+
+manifest.json stays a working-tree read: it is written once at create() and
+never rewritten, so it is immutable and a stale working-tree copy is still
+correct. No manifest conversion is needed for the stale-tree switch.
+
+Remaining work, in order:
+1. download (kata_v2.rb:308-321) tars the working tree, so a stale tree would
+   ship stale content. Convert it to assemble the repo-with-history from git
+   first. This is the one prerequisite for the stale-tree switch.
+2. Replace `git merge --ff-only` with the `git update-ref` CAS advance (the
+   write speedup), leaving the working tree unrefreshed.
 
 
 - - - -
@@ -80,9 +117,11 @@ remove the racy artifact:
    working-tree file in the read path to catch mid-rewrite.
 
 2. Once nothing reads the working tree, the writer no longer needs to refresh
-   it. The fast-forward of `main` can move the ref without checking the new tree
-   out into the main repo (the commit still exists in the object store via the
-   `/tmp` worktree). The main repo effectively becomes bare for the data files.
+   it. Advancing `main` with `git update-ref` (instead of `git merge --ff-only`)
+   moves the ref without checking the new tree out (the commit already exists in
+   the object store via the `/tmp` worktree). The repo stays NON-bare; its
+   working tree just goes stale. We deliberately do NOT go fully bare: that would
+   change the on-disk layout into a de-facto v3 (see the status section above).
 
 Step 2 is what distinguishes this from "just read via git." Reading via git
 fixes the symptom; not refreshing the working tree removes the shared mutable
@@ -93,21 +132,18 @@ there to feed the old read path.
 - - - -
 ## Get a snapshot, not N independent reads
 
-`manifest(id)` (kata_v2.rb:87-94) reads `manifest.json` and then, per option,
-`options.json` as separate reads. If each were its own `git show HEAD:...`,
-HEAD could advance between them and compose files from two different commits.
+This concern turned out to be moot. It would matter only if two *mutable* files
+were read via git and had to agree. After the conversions, the only mutable
+files read via git are `events.json` and `options.json`, and no operation reads
+both via git as a pair: `manifest()` reads `manifest.json` from the working tree
+(immutable) and `options.json` via git, so there is no multi-file git snapshot
+to coordinate.
 
-So a read that spans more than one file must resolve the commit once and read
-every file relative to that one sha:
-
-    sha = git rev-parse HEAD      # or refs/heads/main
-    git show <sha>:manifest.json
-    git show <sha>:options.json
-
-This gives a real point-in-time snapshot. (Today the practical exposure is
-narrow because `worktree_commit` does not rewrite `manifest.json`; only
-`option_set` rewrites `options.json`. But the snapshot rule is the correct shape
-regardless.)
+(Kept for the record: if a future change ever read two mutable files via git
+together, it should resolve one sha once and read both at it, e.g.
+`sha = git rev-parse HEAD` then `git show <sha>:a` / `git show <sha>:b`, rather
+than two independent `git show HEAD:` calls that could straddle a concurrent
+save.)
 
 
 - - - -
@@ -156,8 +192,8 @@ rescue re-reading `events.json` to decide "Out of order event"
     git update-ref refs/heads/main <new-sha> <expected-old-sha>
 
 fails atomically if `main` moved since the writer read it, which is exactly the
-loser-detection, without a checkout. So removing the working tree could also
-replace the merge-plus-rescue dance with something both faster and more precise.
+loser-detection, without a checkout. So this could also replace the
+merge-plus-rescue dance with something both faster and more precise.
 
 What does NOT get faster:
 
@@ -171,9 +207,10 @@ What does NOT get faster:
 - Secondary and indirect: less disk I/O and page-cache churn per save, and less
   read/write disk contention under concurrency. Real but unmeasured.
 
-Confidence note: the git semantics here (bare-repo ref moves, `update-ref`
-compare-and-swap, `merge` needing a working tree) are reasonably certain but have
-not been re-verified from git source in this work.
+Confidence note: the git semantics here (`update-ref` advancing a branch on a
+non-bare repo and leaving the working tree stale, `update-ref` compare-and-swap,
+`merge` needing a working tree) are reasonably certain but have not been
+re-verified from git source in this work.
 
 
 - - - -
@@ -186,17 +223,19 @@ not been re-verified from git source in this work.
   Whether the net is a win needs measuring, not assuming, and runs against the
   overhead-cutting direction of #377-#380.
 
-- Making the main repo bare-for-data is a larger change than swapping the read
-  calls. Anything that assumes a populated working tree must be checked.
-  `download` (kata_v2.rb:308-321) is the awkward one: it `tar`s the repo dir to
-  ship the kata as a real git repo the user can push to GitHub (the generated
-  README literally instructs `git push`). See the download conversion note in
-  the enumeration below for why `git archive` does NOT work here.
+- Stopping the working-tree refresh (the stale-tree switch) requires that
+  nothing reads it for current data. `download` (kata_v2.rb:308-321) is the
+  holdout: it `tar`s the repo dir to ship the kata as a real git repo the user
+  can push to GitHub (the generated README literally instructs `git push`), so a
+  stale tree would ship stale content. It must move to git first. See the
+  download conversion note in the enumeration below for why `git archive` does
+  NOT work here.
 
-- An intermediate option exists: keep the working tree but read via git anyway.
-  That fixes the torn read without the bare-repo work, at the cost of leaving
-  the now-pointless per-save checkout in place. It is a smaller, reversible
-  first step toward the full framing.
+- Where we are now is the safe intermediate state: the working tree is still
+  refreshed by `git merge --ff-only`, but the reads that need current data go
+  through git, so nothing depends on the refresh except `download`. The
+  stale-tree switch (`update-ref` instead of `merge --ff-only`) is the next step
+  once `download` is converted; it is reversible and needs no layout change.
 
 
 - - - -
@@ -258,37 +297,35 @@ Three lines of evidence now agree:
 - - - -
 ## Sequencing and rollout
 
-The two changes have a hard ordering dependency, not just a preferred order:
-the write speedup (ref-only advance, dropping the main-tree checkout) is unsafe
-until nothing reads the working tree. So reads-via-git is the step that unlocks
-the write change, and must land first.
+There is a hard ordering dependency: the write speedup (advancing `main` with
+`update-ref` instead of `merge --ff-only`, leaving the working tree stale) is
+unsafe until nothing reads the working tree for current data.
 
-Step 1: move all reads through git.
-- Independently valuable: it fixes the torn-read race on its own, whether or not
-  step 2 ever happens.
-- The intermediate state is safe and shippable: the ff-merge still refreshes the
-  main working tree, but nothing reads it, so the refresh is harmless waste. The
-  work can pause here indefinitely.
-- Verifiable in isolation: read correctness can be confirmed before the write
-  path is touched at all.
+Step 1 (DONE): move the reads of mutable data through git -- `events.json` (A),
+`options.json` (C), and the rescue read (E). This fixes the torn-read race on
+its own, independently of the write speedup. We are here now: the working tree
+is still refreshed by `merge --ff-only` (harmless waste), and the only thing
+still reading mutable data from it is `download`.
 
-Step 2: stop refreshing the main working tree (ref-only advance, the write
-speedup above). Safe only once step 1 guarantees no reader depends on the
-working tree.
+Step 2: convert `download` to read from git, since its `tar` of the working tree
+would otherwise ship stale content after the switch.
 
-Caveats to hold onto:
+Step 3: the write speedup -- replace `merge --ff-only` with the `update-ref` CAS
+advance, leaving the working tree unrefreshed.
 
-- "All reads" must mean all of them, or step 2 breaks. The full enumeration is
-  in the next section. For the torn-read fix only the reads of files a save
-  actually rewrites need converting (events.json and options.json); the manifest
-  reads are immutable and the download read is special, so they ride with step
-  2. For step 2 (bare repo) every working-tree read must move to git.
+What does NOT need converting:
+- `manifest.json` reads (`read_manifest`): immutable, so a stale working-tree
+  copy stays correct. Stays a working-tree read.
+- version dispatch: was a manifest read on every kata operation; sped up
+  separately by detecting the `.git` dir (see the status section), so it no
+  longer reads `manifest.json` for v2 katas.
 
-- Step 1 alone is a net cost. Reads become git subprocesses (slower per read);
-  the payoff (faster writes) only arrives in step 2. Shipping step 1 and
-  stopping trades read latency for correctness. That is a fine trade if the race
-  is real, but it means the two steps are best planned together rather than
-  step 1 shipped and forgotten.
+So the stale-tree switch needs only events/options/rescue (done) plus `download`
+(step 2) -- NOT "every working-tree read", and no bare repo.
+
+Cost note: reads of mutable data become git subprocesses instead of `File.read`;
+the payoff (skipping the per-save checkout) arrives with the write speedup. So
+the two are best planned together rather than stopping after step 1.
 
 
 - - - -
@@ -297,8 +334,7 @@ Caveats to hold onto:
 Every read primitive (`read_events` / `read_options` / `read_manifest` ->
 `read_json` -> `read` -> `disk.file_read_command`) and every shell command that
 touches a tree, classified by which tree it reads. Only reads of the main repo
-working tree are the shared racy artifact that step 2 (making main bare) would
-break.
+working tree of *mutable* data are broken by the stale-tree switch.
 
 Reads of the main working tree, split by whether the file can actually tear (a
 save rewrites it, so a concurrent reader can be caught in the git merge --ff-only
@@ -321,28 +357,31 @@ Convert A, C, E by reading at `HEAD` (`git show HEAD:<file>`). Each reads a
 single file, so no multi-file snapshot is needed; `HEAD` advances atomically on
 the ff-merge and always resolves, so no retry (unlike the numeric tags).
 
-Immutable, or deferred to step 2 (bare repo). Not part of the torn-read fix:
+Immutable or already handled. Not part of the torn-read fix, and (except
+download) not needed for the stale-tree switch either:
 
 - B. `manifest(id)`, kata_v2.rb:88 (`read_manifest(id)`) reads `manifest.json`.
   manifest.json is written once by `create()` and never rewritten (saves rewrite
   events.json and metadata; `option_set` rewrites options.json), so it is
-  immutable and a save's ff-merge never refreshes it. It cannot tear, so it does
-  not need reading via git for correctness; only the bare-repo goal needs it.
-- `from_path` (model.rb:180), MISSED by this kata_v2-scoped enumeration:
-  `Model#kata` and `Model#group` read manifest.json from the working tree to
-  dispatch on version, before any Kata_vN is instantiated, on every operation.
-  Also immutable (no torn risk), but version-agnostic: v0/v1 katas have no git
-  repo, so this read cannot uniformly use `git show`. Converting it belongs with
-  step 2, where the v0/v1 dispatch has to be designed.
+  immutable: it cannot tear, and a stale working-tree copy stays correct. So it
+  STAYS a working-tree read -- no conversion needed, now or for the stale-tree
+  switch.
+- Version dispatch (`Model#kata`, model.rb): RESOLVED separately. It used to read
+  `manifest.json` on every kata operation just to get the version; it now detects
+  the `.git` dir (=> v2) with a legacy `manifest.json` fallback that asserts
+  v0/v1. So this is no longer a manifest read for v2 katas. (`Model#group` still
+  reads its manifest; v2 groups are flat files, outside this scope.)
 - D. `download(id)`, kata_v2.rb:316 (`tar -czf ... .` in `repo_dir`) reads the
-  whole working tree. NOT a `git archive` swap: `git archive` emits only the
-  tree at a commit, with no `.git` and no history, but download's contract is to
-  ship the whole repo with history so the user can push it to GitHub. The
-  existing test `kata_download.rb` (kL375s) pins that (asserts the unpacked tgz
-  contains a working `.git`, `git tag`, `git log`); a naive `git archive` would
-  fail it. Under a bare main, download must reconstruct a pushable repo another
-  way (tar the bare repo's `.git`, or `git clone` it into a temp dir and tar
-  that).
+  whole working tree -- the one remaining conversion, and the prerequisite for
+  the stale-tree switch (a stale tree would `tar` stale content). NOT a
+  `git archive` swap: `git archive` emits only the tree at a commit, with no
+  `.git` and no history, but download's contract is to ship the whole repo with
+  history so the user can push it to GitHub. The existing test `kata_download.rb`
+  (kL375s) pins that (asserts the unpacked tgz contains a working `.git`,
+  `git tag`, `git log`); a naive `git archive` would fail it. So download must
+  assemble a pushable repo-with-history from git another way (e.g. `git clone`
+  the repo into a temp dir and `tar` that, or build the `.git` from the object
+  store).
 
 Reads that are NOT of the main working tree (no conversion needed for the race):
 
@@ -360,7 +399,8 @@ Reads that are NOT of the main working tree (no conversion needed for the race):
 - J. `download`, kata_v2.rb:319 (`File.read(tgz_file_path)`) reads the freshly
   produced `.tgz` in `Dir.mktmpdir`, i.e. tar's own output, not the kata tree.
 
-Wrinkle for step 2: F and G read the `/tmp/<branch>` worktree created by
-`git worktree add` (:530), which stays checked out for the save's duration.
-Making the main repo bare does not affect them, so step 2 is safe for F and G as
-written. Only A through E need to move off the main working tree.
+Note: F and G read the `/tmp/<branch>` worktree created by `git worktree add`
+(:530), which stays checked out for the save's duration. The stale-tree switch
+only stops refreshing the *main* working tree, so it does not affect F and G.
+Of the main-tree reads, only events/options/rescue (A, C, E -- done) and
+`download` (D) ever needed converting.

--- a/source/server/model/kata_v2.rb
+++ b/source/server/model/kata_v2.rb
@@ -310,15 +310,19 @@ class Kata_v2
   # - - - - - - - - - - - - - - - - - - - - - -
 
   def download(id)
-    # If id == 'vqzjS7' then repo_dir(id) is '/cyber-dojo/katas/vq/zj/S7/'
-    # and the root-dir of the tar command is 'S7'.
-    # So using --transform to create root-dir with a name
-    # matching the tzg filename itself.
+    # Build the download from committed git state, not the working tree, so it
+    # is correct even when the working tree is stale (see docs/reads-via-git.md).
+    # git clone gives a fresh repo with the full history and tags and a checkout
+    # of HEAD; remove the local-path origin it adds so the result is a plain repo
+    # the user can push to GitHub. The clone dir is named after the tgz, so the
+    # tarball's root dir matches the filename.
     year, month, day = *time.now
     user_name = "cyber-dojo-#{year}-#{month}-#{day}-#{id}"
     Dir.mktmpdir do |tmp_dir|
-      tgz_command = "tar -czf #{tmp_dir}/#{user_name}.tgz --transform s/^./#{user_name}/ ."
-      shell.assert_cd_exec(repo_dir(id), tgz_command)
+      clone_dir = "#{tmp_dir}/#{user_name}"
+      shell.assert_cd_exec(repo_dir(id), "git clone --quiet . #{clone_dir}")
+      shell.assert_cd_exec(clone_dir, "git remote remove origin")
+      shell.assert_cd_exec(tmp_dir, "tar -czf #{user_name}.tgz #{user_name}")
       tgz_file_path = "#{tmp_dir}/#{user_name}.tgz"
       [ "#{user_name}.tgz", Base64.encode64(File.read(tgz_file_path)) ]
     end

--- a/test/server/config/coverage_metrics_limits.rb
+++ b/test/server/config/coverage_metrics_limits.rb
@@ -2,12 +2,12 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 2987 ],
+    [ 'test.lines.total'    , '<=', 3006 ],
     [ 'test.lines.missed'   , '<=', 0    ],
     [ 'test.branches.total' , '<=', 8    ],
     [ 'test.branches.missed', '<=', 0    ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 1603 ],
+    [ 'code.lines.total'    , '<=', 1605 ],
     [ 'code.lines.missed'   , '<=', 0    ],
     [ 'code.branches.total' , '<=', 225  ],
     [ 'code.branches.missed', '<=', 0    ],

--- a/test/server/config/test_metrics_limits.rb
+++ b/test/server/config/test_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test_count',    '>=', 364 ],
+    [ 'test_count',    '>=', 365 ],
     [ 'total_time',    '<=',  50 ],
     [ nil ],
     [ 'failure_count', '<=', 0   ],

--- a/test/server/kata_download.rb
+++ b/test/server/kata_download.rb
@@ -31,8 +31,23 @@ class KataDownloadTest < TestBase
         dir_path = "#{tmp_dir}/#{dir_name}"
         shell.assert_cd_exec(dir_path, '[ -d .git ]')
         tags = shell.assert_cd_exec(dir_path, 'git tag')
-        assert_equal 3, tags.split("\n").count
-        assert_last_commit_message(dir_path, '2 ran tests, no prediction, got red')
+        # tags are exactly 0,1,2 (names, not just count)
+        assert_equal %w(0 1 2), tags.split("\n").sort
+        # full history: one commit per event, right messages, newest first
+        subjects = shell.assert_cd_exec(dir_path, 'git log --pretty=%s').split("\n")
+        assert_equal [
+          '2 ran tests, no prediction, got red',
+          '1 ran tests, no prediction, got red',
+          '0 kata creation',
+        ], subjects
+        # each tag points at the commit for its index (commit<->tag correspondence)
+        %w(0 1 2).each do |i|
+          subject = shell.assert_cd_exec(dir_path, "git log -1 --pretty=%s #{i}")
+          assert subject.start_with?("#{i} "), "tag #{i} -> #{subject}"
+        end
+        # working tree is checked out clean at HEAD (nothing missing or modified)
+        status = shell.assert_cd_exec(dir_path, 'git status --porcelain')
+        assert_equal '', status, status
         actual_cyber_dojo_sh = shell.assert_cd_exec(dir_path, 'cat files/cyber-dojo.sh')
         #assert_equal 'pytest *_test.rb', cyber_dojo_sh
         assert_equal expected_cyber_dojo_sh, actual_cyber_dojo_sh
@@ -66,11 +81,33 @@ class KataDownloadTest < TestBase
     assert readme.include?("- Language & test-framework: `Bash, bats`"), readme
   end
 
-  def assert_last_commit_message(dir_path, expected)
-    latest_commits_messages = shell.assert_cd_exec(dir_path, "git log --abbrev-commit --pretty=oneline")
-    last_commits_message = latest_commits_messages.lines[0]
-    diagnostic = "\nexpected:#{expected}\n  actual:#{last_commits_message}"
-    assert last_commits_message.include?(expected), diagnostic
+  version_test 2, 'kL375v', %w(
+  | download ships committed state, not the working tree. Corrupting the
+  | working-tree events.json (as the planned stale-working-tree write path would
+  | leave it) does not corrupt the downloaded repo, because download is built
+  | from the committed git state, not the working-tree files.
+  ) do
+    stdout  = { 'content' => '', 'truncated' => false }
+    stderr  = { 'content' => '', 'truncated' => false }
+    summary = { 'colour' => 'red' }
+    in_kata do |id|
+      files = kata_event(id, 0)['files']
+      kata_ran_tests(id, 1, files, stdout, stderr, '0', summary)
+      kata_ran_tests(id, 2, files, stdout, stderr, '1', summary)
+
+      File.write(working_tree_path(id, 'events.json'), 'CORRUPT-NOT-JSON')
+
+      year, month, day = 2021, 7, 11
+      externals.instance_exec { @time = TimeStub.new([year, month, day]) }
+      tgz_filename, encoded64 = *model.kata_download(id:id)
+      Dir.mktmpdir do |tmp_dir|
+        File.write("#{tmp_dir}/#{tgz_filename}", Base64.decode64(encoded64))
+        shell.assert_cd_exec(tmp_dir, "tar -xf #{tgz_filename}")
+        dir_path = "#{tmp_dir}/cyber-dojo-#{year}-#{month}-#{day}-#{id}"
+        events = JSON.parse(shell.assert_cd_exec(dir_path, 'cat events.json'))
+        assert_equal 3, events.size
+      end
+    end
   end
 
 end

--- a/test/server/kata_torn_read.rb
+++ b/test/server/kata_torn_read.rb
@@ -242,13 +242,4 @@ class KataTornReadTest < TestBase
   end
 =end
 
-  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-  # Absolute path of a file in a kata's working tree, e.g.
-  # /cyber-dojo/katas/Sy/G9/sT/events.json (same layout as
-  # assert_tag_commit_message in test_base.rb).
-  def working_tree_path(id, filename)
-    "/#{disk.root_dir}/katas/#{id[0..1]}/#{id[2..3]}/#{id[4..5]}/#{filename}"
-  end
-
 end

--- a/test/server/test_base.rb
+++ b/test/server/test_base.rb
@@ -77,4 +77,10 @@ class TestBase < Id58TestBase
     diagnostic = "\nexpected:#{expected}\n  actual:#{line}"
     assert line.include?(expected), diagnostic
   end
+
+  # Absolute path of a file in a kata's working tree, e.g.
+  # /cyber-dojo/katas/Sy/G9/sT/events.json
+  def working_tree_path(id, filename)
+    "/#{disk.root_dir}/katas/#{id[0..1]}/#{id[2..3]}/#{id[4..5]}/#{filename}"
+  end
 end


### PR DESCRIPTION
  download tarred the repo dir's working tree. After the planned write speedup
  (advance main with git update-ref instead of git merge --ff-only, leaving the
  working tree unrefreshed), that tree goes stale, so the download would ship
  stale content. download now git-clones the repo into a temp dir (full history,
  tags, and a fresh checkout of HEAD, all read from .git so independent of the
  working tree), removes the local-path origin the clone adds, then tars the
  clone. This is correct today and after the switch.

  Tests (kata_download.rb):
  - Strengthen kL375s to pin the structure the rework must preserve: tag names are exactly 0,1,2 (not just count 3), the full commit history (one commit per event, right messages, right order), commit<->tag correspondence, and a clean HEAD checkout (git status --porcelain empty). Drops the old count-only and HEAD-message-only checks (and the assert_last_commit_message helper).
  - Add kL375v: with the working-tree events.json corrupted, the download still ships the committed events.json, proving it does not read the working tree.

  Hoist working_tree_path into test_base.rb (now used by both kata_download and
  kata_torn_read).

  docs/reads-via-git.md: reframe the end-state from a bare repo to non-bare plus a
  stale working tree advanced by an update-ref compare-and-swap (no v3), and record
  current status and remaining work.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>