### PR TITLE
Advance main via git update-ref instead of git merge --ff-only

### DIFF
--- a/docs/reads-via-git.md
+++ b/docs/reads-via-git.md
@@ -11,7 +11,7 @@ original reasoning.
 - - - -
 ## Current status and decisions
 
-Done:
+Done (all of it):
 - The torn-read fix. events.json, options.json, and the worktree_commit
   out-of-order rescue now read committed state via `git show HEAD:<file>`
   instead of the working tree (the A/C/E conversions in the enumeration). The
@@ -20,28 +20,31 @@ Done:
   of its `.git` dir (a cheap stat) instead of reading manifest.json, with a
   legacy manifest fallback that asserts v0/v1. (`Model#group` is unchanged: v2
   groups are not git repos.)
+- download. Builds the tgz from a `git clone` of committed state (full history,
+  tags, fresh HEAD checkout), not a `tar` of the working tree, so it is correct
+  even when the working tree is stale.
+- The write speedup. A save advances `main` with a `git update-ref`
+  compare-and-swap (`fast_forward_main_via_worktree`) instead of
+  `git merge --ff-only`, so it no longer checks the new tree out; the working
+  tree is left stale. The CAS preserves loser-detection (a concurrent save
+  whose base moved fails and resolves to "Out of order event").
 
 Decided against: making the kata repo bare. A bare repo is a different on-disk
 layout, so it would be a de-facto new format (v3) and a population of mixed
 bare/non-bare v2 dirs. We do not want that.
 
-Chosen end-state instead: keep the repo NON-bare, but stop refreshing its
-working tree. Advance `main` with `git update-ref` (compare-and-swap) instead of
-`git merge --ff-only`, so the per-save checkout is skipped and the working tree
-just goes stale. A stale working tree is harmless because the reads that need
-current data already go through git. This is the write speedup, with no bare
-repo and no v3.
+End-state (now in place): the repo stays NON-bare, but saves no longer refresh
+its working tree; they advance `main` with `git update-ref`, leaving the working
+tree stale. A stale working tree is harmless because every read of current data
+goes through git. No bare repo, no v3.
 
 manifest.json stays a working-tree read: it is written once at create() and
 never rewritten, so it is immutable and a stale working-tree copy is still
-correct. No manifest conversion is needed for the stale-tree switch.
+correct. No manifest conversion was needed.
 
-Remaining work, in order:
-1. download (kata_v2.rb:308-321) tars the working tree, so a stale tree would
-   ship stale content. Convert it to assemble the repo-with-history from git
-   first. This is the one prerequisite for the stale-tree switch.
-2. Replace `git merge --ff-only` with the `git update-ref` CAS advance (the
-   write speedup), leaving the working tree unrefreshed.
+Remaining work: none. The reads-via-git conversions (events, options, rescue,
+download), the `.git` version dispatch, and the `update-ref` write speedup are
+all in place. The sections below record the original problem and reasoning.
 
 
 - - - -
@@ -166,23 +169,28 @@ save.)
 Moving reads off the working tree does not only fix a race. It removes work the
 write path currently does solely to keep that working tree readable.
 
-The direct win: drop the working-tree refresh from every save. Today
-`git merge --ff-only <branch>` (kata_v2.rb:533) advances `main` AND checks the
-new tree out into the main repo's working dir. The checkout half exists only so
-the working-tree files can be read. If nothing reads them, it is pure waste, and
-the fast-forward can become a ref-only advance:
+The change: drop the working-tree refresh from every save. The old
+`git merge --ff-only` advanced `main` AND checked the new tree out into the main
+repo's working dir. The checkout half existed only so the working-tree files
+could be read; once nothing reads them it is waste, so the advance becomes a
+ref-only update:
 
-    git update-ref refs/heads/main <branch-sha>
+    git update-ref refs/heads/main <branch> <branch>^
 
 The commit already exists in the shared object store (it was built in the
 `/tmp` worktree), so moving the ref is all that is logically required.
 
-Magnitude: the working-tree refresh writes every file in the kata tree to disk,
-including `events.json`, which grows with the number of events. Late in a long
-session every save rewrites an ever-larger `events.json` into the main working
-tree on top of having already written it once in the `/tmp` worktree. Skipping
-the refresh roughly halves the per-save file-write work, and the saving grows
-with session length.
+Magnitude (unmeasured, and not a clear-cut win). The refresh re-writes the files
+that changed in the commit -- `events.json` plus the small metadata files
+(`stdout`/`stderr`/`status`/`truncations.json`); unchanged `files/` are not
+re-written. Those are small writes, except `events.json`, which grows with the
+session. But the dominant per-save cost is git process startup, not this file
+I/O, and the advance is still one git subprocess either way (merge, vs
+update-ref with `branch^` as the CAS old-value). So skipping the checkout is a
+real saving mainly when `events.json` is large (long sessions); for small katas
+it may be a wash. This has not been benchmarked -- the honest claim is "removes
+the per-save working-tree checkout", not "measurably faster". The torn-read fix
+(reads-via-git) stands on its own correctness merits regardless.
 
 A bonus: cheaper, more precise concurrency detection. Write/write concurrency is
 caught today by `git merge --ff-only` failing on a non-fast-forward, then the
@@ -303,15 +311,13 @@ unsafe until nothing reads the working tree for current data.
 
 Step 1 (DONE): move the reads of mutable data through git -- `events.json` (A),
 `options.json` (C), and the rescue read (E). This fixes the torn-read race on
-its own, independently of the write speedup. We are here now: the working tree
-is still refreshed by `merge --ff-only` (harmless waste), and the only thing
-still reading mutable data from it is `download`.
+its own, independently of the write speedup.
 
-Step 2: convert `download` to read from git, since its `tar` of the working tree
-would otherwise ship stale content after the switch.
+Step 2 (DONE): convert `download` to read from git (a `git clone`), since its
+`tar` of the working tree would otherwise ship stale content after the switch.
 
-Step 3: the write speedup -- replace `merge --ff-only` with the `update-ref` CAS
-advance, leaving the working tree unrefreshed.
+Step 3 (DONE): the write speedup -- replace `merge --ff-only` with the
+`update-ref` CAS advance, leaving the working tree unrefreshed.
 
 What does NOT need converting:
 - `manifest.json` reads (`read_manifest`): immutable, so a stale working-tree
@@ -371,17 +377,16 @@ download) not needed for the stale-tree switch either:
   the `.git` dir (=> v2) with a legacy `manifest.json` fallback that asserts
   v0/v1. So this is no longer a manifest read for v2 katas. (`Model#group` still
   reads its manifest; v2 groups are flat files, outside this scope.)
-- D. `download(id)`, kata_v2.rb:316 (`tar -czf ... .` in `repo_dir`) reads the
-  whole working tree -- the one remaining conversion, and the prerequisite for
-  the stale-tree switch (a stale tree would `tar` stale content). NOT a
-  `git archive` swap: `git archive` emits only the tree at a commit, with no
-  `.git` and no history, but download's contract is to ship the whole repo with
-  history so the user can push it to GitHub. The existing test `kata_download.rb`
-  (kL375s) pins that (asserts the unpacked tgz contains a working `.git`,
-  `git tag`, `git log`); a naive `git archive` would fail it. So download must
-  assemble a pushable repo-with-history from git another way (e.g. `git clone`
-  the repo into a temp dir and `tar` that, or build the `.git` from the object
-  store).
+- D. `download(id)` (DONE): formerly `tar`ed the working tree; now `git clone`s
+  the repo into a temp dir (full history, tags, fresh HEAD checkout), removes
+  the local-path origin, and `tar`s the clone, so it works with a stale working
+  tree. NOT a `git archive` swap: `git archive` emits only the tree at a commit,
+  with no `.git` and no history, but download's contract is to ship the whole
+  repo with history so the user can push it to GitHub. The test `kata_download.rb`
+  (kL375s) pins that (asserts the unpacked tgz has a working `.git`, the right
+  tags, full commit history, commit<->tag correspondence, and a clean HEAD
+  checkout); kL375v pins independence from a corrupt working tree. A naive
+  `git archive` would fail kL375s.
 
 Reads that are NOT of the main working tree (no conversion needed for the race):
 

--- a/source/server/config/puma.rb
+++ b/source/server/config/puma.rb
@@ -5,11 +5,11 @@ require 'etc'
 environment 'production'
 rackup "#{__dir__}/config.ru"
 
-# Each POST write happens inside a git worktree and is merged back to the
-# main branch via git merge --ff-only (kata_v2.rb). If two concurrent writes
-# target the same kata, only one fast-forward merge will succeed; the other
-# fails and is detected as an 'Out of order event' error, which the web layer
-# treats as an out-of-sync condition and shows a dialog.
+# Each POST write happens inside a git worktree, then advances the main branch
+# to it with a git update-ref compare-and-swap (kata_v2.rb). If two concurrent
+# writes target the same kata, only one CAS will succeed; the other fails and is
+# detected as an 'Out of order event' error, which the web layer treats as an
+# out-of-sync condition and shows a dialog.
 #
 # GET requests always see a consistent committed state because all writes are
 # atomic at the git level.

--- a/source/server/model/kata_v2.rb
+++ b/source/server/model/kata_v2.rb
@@ -292,7 +292,7 @@ class Kata_v2
     if option_get(id, name) === value
       return
     end
-    git_ff_merge_worktree(repo_dir(id)) do |worktree|
+    fast_forward_main_via_worktree(repo_dir(id)) do |worktree|
       # Read the worktree directly, not via git (unlike option_get's main-repo
       # read): the worktree is a private checkout this option_set just created
       # (unique branch), so nothing else rewrites it (no torn-read race), and we
@@ -400,21 +400,22 @@ class Kata_v2
     # 1. Sequential stale index (inside the worktree block):
     #    The client sends an index that is behind the current last_index, but
     #    there is no concurrent request. Without the explicit check, the worktree
-    #    commit and the git merge --ff-only would both SUCCEED, silently writing
-    #    corrupt data (e.g. two events.json entries with the same index). The
-    #    unless check catches this before any git work is done.
+    #    commit and the ref update would both SUCCEED, silently writing corrupt
+    #    data (e.g. two events.json entries with the same index). The unless
+    #    check catches this before any git work is done.
     #
     # 2. Concurrent write (rescue block):
     #    Two requests for the same kata arrive simultaneously. Both create their
     #    worktrees from the same HEAD, both pass the index check (they both see
     #    the same last_index), and both commit to their respective worktree
-    #    branches. Whichever request reaches git merge --ff-only second will fail
-    #    because HEAD has already moved forward. The rescue detects this by
-    #    re-reading events.json from the main repo: if last_index >= index, a
-    #    concurrent write succeeded first, so "Out of order event" is raised.
-    #    Any other failure (e.g. disk error) is re-raised as-is.
+    #    branches. Whichever request reaches the update-ref compare-and-swap
+    #    second will fail because main has already moved forward. The rescue
+    #    detects this by re-reading events.json from the main repo: if
+    #    last_index >= index, a concurrent write succeeded first, so "Out of
+    #    order event" is raised. Any other failure (e.g. disk error) is
+    #    re-raised as-is.
     all_events = nil
-    git_ff_merge_worktree(repo_dir(id)) do |worktree|
+    fast_forward_main_via_worktree(repo_dir(id)) do |worktree|
       # Read the worktree directly, not via git (unlike the main-repo reads).
       # Safe and required: the worktree is a private checkout this save just
       # created (git worktree add, unique branch), so nothing else rewrites it
@@ -484,11 +485,11 @@ class Kata_v2
     end
     all_events
   rescue
-    # Read the tip through git, not the working tree: a concurrent save's
-    # git merge --ff-only may be rewriting the working-tree events.json right
-    # now, and reading it directly here would mask the out-of-order with a raw
-    # torn-read diagnostic. HEAD advances atomically, so this sees the latest
-    # committed events. See read_events_via_git and docs/reads-via-git.md.
+    # Read the tip through git, not the working tree: the working tree is stale
+    # (saves no longer refresh it), so it would not give the latest committed
+    # events. HEAD advances atomically via update-ref, so this sees the tip and
+    # resolves out-of-order cleanly. See read_events_via_git and
+    # docs/reads-via-git.md.
     current_events = read_events_via_git(id)
     if current_events.last['index'] >= index
       raise "Out of order event for #{id}"
@@ -500,9 +501,9 @@ class Kata_v2
 
   # Reads the kata git tree at the commit tagged pos_index as a tar stream.
   #
-  # A save commits its event (git merge --ff-only) and then, as a separate
-  # step, writes that index's numeric tag (git tag <index> HEAD). A concurrent
-  # reader can observe the new index in events.json before its numeric tag
+  # A save commits its event (advancing main via git update-ref) and then, as a
+  # separate step, writes that index's numeric tag (git tag <index> HEAD). A
+  # concurrent reader can observe the new index in events.json before its tag
   # exists, so "git archive <index>" fails with "fatal: not a valid object
   # name". The caller has already validated pos_index against events.json, so
   # this failure is the transient tag-write window: retry briefly until the
@@ -543,19 +544,19 @@ class Kata_v2
   # - - - - - - - - - - - - - - - - - - - - - -
 
   # Reads the kata's committed events.json through git rather than off the
-  # working tree. HEAD (the kata's main branch) advances atomically on a save's
-  # git merge --ff-only, and the committed blob exists before the ref moves, so
-  # this always returns a whole, consistent events.json. A plain working-tree
-  # File.read can instead observe the torn-read window while the merge rewrites
-  # the file (unlink + O_EXCL create + chunked write). See docs/reads-via-git.md.
+  # working tree. The working tree is stale (saves no longer refresh it; they
+  # advance main with git update-ref, no checkout), so its events.json is not
+  # the latest. HEAD (the kata's main branch) advances atomically and the
+  # committed blob exists before the ref moves, so this always returns the
+  # whole, consistent, latest events.json. See docs/reads-via-git.md.
   def read_events_via_git(id)
     json_parse(Utf8.clean(git_show(id, 'events.json')))
   end
 
   # Reads the kata's committed options.json through git rather than off the
-  # working tree. options.json is rewritten by option_set's git merge --ff-only,
-  # so a working-tree File.read can hit the torn-read window; reading at HEAD
-  # (which advances atomically) cannot. See git_show and docs/reads-via-git.md.
+  # working tree. option_set advances main with git update-ref without a
+  # checkout, so the working-tree options.json is stale; reading at HEAD (which
+  # advances atomically) gives the latest. See git_show and docs/reads-via-git.md.
   # Note this is the by-id read only; option_set reads options.json from its own
   # /tmp worktree via read_options(worktree), which stays a working-tree read.
   def read_options_via_git(id)
@@ -569,14 +570,21 @@ class Kata_v2
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def git_ff_merge_worktree(repo_dir)
+  def fast_forward_main_via_worktree(repo_dir)
     branch = random.alphanumeric(8)
     worktree_dir = "/tmp/#{branch}"
     begin
       shell.assert_cd_exec(repo_dir, "git worktree add #{worktree_dir}")
       worktree = External::Disk.new(worktree_dir)
       yield worktree
-      shell.assert_cd_exec(repo_dir, "git merge --ff-only #{branch}")
+      # Advance main with a compare-and-swap ref update, not git merge --ff-only:
+      # it moves the ref without checking the new tree out, leaving the main
+      # working tree stale (nothing reads it now; see docs/reads-via-git.md).
+      # The block makes exactly one commit, so #{branch}^ is the commit main was
+      # at when this worktree was created. The old-value precondition makes
+      # update-ref fail (raise) if a concurrent save advanced main since then,
+      # which the rescue maps to "Out of order event".
+      shell.assert_cd_exec(repo_dir, "git update-ref refs/heads/main #{branch} #{branch}^")
     ensure
       shell.cd_exec(repo_dir, "git worktree remove --force #{branch}")
       shell.cd_exec(repo_dir, "git branch --delete --force #{branch}")
@@ -608,10 +616,11 @@ class Kata_v2
   def read_manifest(id)
     # eg { "display_name": "Ruby, MiniTest",...}
     # Read from the working tree, not via git. manifest.json is written once at
-    # create() and never rewritten (saves rewrite events.json and metadata;
-    # option_set rewrites options.json), so it is immutable and a concurrent
-    # save's git merge --ff-only never refreshes it. It therefore cannot be
-    # caught in a torn-read window and does not need reading via git. See
+    # create() and never rewritten (saves change events.json and metadata;
+    # option_set changes options.json; nothing changes the manifest), so it is
+    # immutable. Its create-time working-tree copy therefore always equals the
+    # committed content, even now that saves no longer refresh the working tree,
+    # so reading it from the working tree is correct and needs no git. See
     # docs/reads-via-git.md.
     read_json(disk, manifest_filename(id))
   end

--- a/test/client/kata_concurrent_saves_test.rb
+++ b/test/client/kata_concurrent_saves_test.rb
@@ -6,8 +6,8 @@ class KataConcurrentSavesTest < TestBase
   | N concurrent kata_ran_tests calls to the same kata-id all use index=1.
   | Exactly one succeeds. The remaining N-1 all get 'Out of order event':
   | either from the index check (sequential case) or from the failed
-  | git merge --ff-only (concurrent case). Even sequential execution cannot
-  | produce more than one success since all threads hardcode index=1.
+  | update-ref compare-and-swap (concurrent case). Even sequential execution
+  | cannot produce more than one success since all threads hardcode index=1.
   ) do
     n = 10
     in_kata do |id|

--- a/test/server/config/coverage_metrics_limits.rb
+++ b/test/server/config/coverage_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 3006 ],
+    [ 'test.lines.total'    , '<=', 3016 ],
     [ 'test.lines.missed'   , '<=', 0    ],
     [ 'test.branches.total' , '<=', 8    ],
     [ 'test.branches.missed', '<=', 0    ],

--- a/test/server/config/test_metrics_limits.rb
+++ b/test/server/config/test_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test_count',    '>=', 365 ],
+    [ 'test_count',    '>=', 366 ],
     [ 'total_time',    '<=',  50 ],
     [ nil ],
     [ 'failure_count', '<=', 0   ],

--- a/test/server/kata_ran_tests.rb
+++ b/test/server/kata_ran_tests.rb
@@ -81,9 +81,9 @@ class KataRanTestsTest < TestBase
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   version_test 2, 'Sp4DkD', %w(
-  | There is a window between the git merge --ff-only (which updates
-  | events.json to include the new index) and the separate git tag
-  | <index> HEAD that records the numeric tag for that index. A concurrent
+  | There is a window between the ref advance (git update-ref, which moves
+  | main to the commit that adds the new index to events.json) and the separate
+  | git tag <index> HEAD that records the numeric tag for that index. A concurrent
   | save that loses the race reads the new last_index from events.json,
   | then calls event() -> git archive --format=tar <index>, which fails
   | with "not a valid object name" because the numeric tag is not written
@@ -226,6 +226,30 @@ class KataRanTestsTest < TestBase
     assert_raises(NoLongerImplementedError) do
       kata_ran_tests(id, 1, files, data['stdout'], data['stderr'], data['status'], red_summary)
     end
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  version_test 2, 'Sp4DkG', %w(
+  | A save advances HEAD with git update-ref, not git merge --ff-only, so it
+  | does NOT refresh the main working tree (the write speedup). Reads via git
+  | still see the new committed state, but the save leaves the working-tree
+  | events.json untouched.
+  ) do
+    id     = kata_create(custom_manifest)
+    files  = kata_event(id, 0)['files']
+    stdout = { 'content' => '', 'truncated' => false }
+    stderr = { 'content' => '', 'truncated' => false }
+
+    path   = working_tree_path(id, 'events.json')
+    before = File.read(path)
+
+    kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary)
+
+    # correctness: the committed state advanced (read via git)
+    assert_equal 2, kata_events(id).size
+    # the speedup: the save did not refresh the working tree
+    assert_equal before, File.read(path)
   end
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/test/server/kata_torn_read.rb
+++ b/test/server/kata_torn_read.rb
@@ -4,10 +4,10 @@ require 'fileutils'
 class KataTornReadTest < TestBase
 
   version_test 2, 'Tn6Wb1', %w(
-  | events() reads committed state through git, not the working tree, so a
-  | partial working-tree events.json (the torn-read window during a save's
-  | git merge --ff-only) does not affect the read. Truncating the working-tree
-  | events.json leaves kata_events returning the committed events unchanged.
+  | events() reads committed state through git, not the working tree, so the
+  | working-tree events.json (now stale: saves no longer refresh it) does not
+  | affect the read. Truncating the working-tree events.json leaves kata_events
+  | returning the committed events unchanged.
   ) do
     in_kata do |id|
       files  = kata_event(id, 0)['files']
@@ -30,9 +30,9 @@ class KataTornReadTest < TestBase
 
   version_test 2, 'Tn6Wb2', %w(
   | events() reads committed state through git, not the working tree, so an
-  | absent working-tree events.json (the ENOENT window during a save's
-  | git merge --ff-only) does not affect the read. Deleting the working-tree
-  | events.json leaves kata_events returning the committed events unchanged.
+  | absent (or stale) working-tree events.json does not affect the read.
+  | Deleting the working-tree events.json leaves kata_events returning the
+  | committed events unchanged.
   ) do
     in_kata do |id|
       files  = kata_event(id, 0)['files']
@@ -51,11 +51,10 @@ class KataTornReadTest < TestBase
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   version_test 2, 'Tn6Wb4', %w(
-  | option_get() reads options.json through git, not the working tree, so a
-  | partial working-tree options.json (the torn-read window during a concurrent
-  | option_set's git merge --ff-only) does not affect the read. Truncating the
-  | working-tree options.json leaves kata_option_get returning the committed
-  | value unchanged.
+  | option_get() reads options.json through git, not the working tree, so the
+  | working-tree options.json (stale: option_set no longer refreshes it) does
+  | not affect the read. Truncating the working-tree options.json leaves
+  | kata_option_get returning the committed value unchanged.
   ) do
     in_kata do |id|
       expected = kata_option_get(id, 'theme')
@@ -72,10 +71,9 @@ class KataTornReadTest < TestBase
 
   version_test 2, 'Tn6Wb5', %w(
   | option_get() reads options.json through git, not the working tree, so an
-  | absent working-tree options.json (the ENOENT window during a concurrent
-  | option_set's git merge --ff-only) does not affect the read. Deleting the
-  | working-tree options.json leaves kata_option_get returning the committed
-  | value unchanged.
+  | absent (or stale) working-tree options.json does not affect the read.
+  | Deleting the working-tree options.json leaves kata_option_get returning the
+  | committed value unchanged.
   ) do
     in_kata do |id|
       expected = kata_option_get(id, 'theme')
@@ -90,11 +88,10 @@ class KataTornReadTest < TestBase
 
   version_test 2, 'Tn6Wb6', %w(
   | The worktree_commit rescue decides "Out of order event" by reading the tip
-  | committed events.json through git, not the working tree. A concurrent save's
-  | git merge --ff-only can leave the working-tree events.json torn while the
-  | rescue runs; reading it directly would mask the out-of-order with a raw JSON
-  | error. With a truncated working-tree events.json, a stale save still reports
-  | "Out of order event".
+  | committed events.json through git, not the working tree. The working tree is
+  | stale (saves no longer refresh it), so reading it directly could mask the
+  | out-of-order with a raw JSON/IO error. With a truncated working-tree
+  | events.json, a stale save still reports "Out of order event".
   ) do
     in_kata do |id|
       files  = kata_event(id, 0)['files']
@@ -116,10 +113,9 @@ class KataTornReadTest < TestBase
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   version_test 2, 'Tn6Wb7', %w(
-  | As Tn6Wb6 but for the ENOENT window: with the working-tree events.json
-  | deleted, the worktree_commit rescue still reports "Out of order event"
-  | because it reads the tip through git rather than the missing working-tree
-  | file.
+  | As Tn6Wb6 but with the working-tree events.json absent (deleted): the
+  | worktree_commit rescue still reports "Out of order event" because it reads
+  | the tip through git rather than the missing working-tree file.
   ) do
     in_kata do |id|
       files  = kata_event(id, 0)['files']

--- a/test/server/kata_worktree_cleanup.rb
+++ b/test/server/kata_worktree_cleanup.rb
@@ -36,14 +36,15 @@ class KataWorktreeCleanupTest < TestBase
   |    [-8] ["git diff 0 --staged --shortstat ..."]
   |    [-7] ["git add ."]
   |    [-6] ["git commit --message '...' --quiet"]
-  |    [-5] ["git merge --ff-only BRANCH"]
+  |    [-5] ["git update-ref refs/heads/main BRANCH BRANCH^"]
   |    [-4] "git worktree remove --force BRANCH"   <- cd_exec
   |    [-3] "git branch --delete --force BRANCH"   <- cd_exec
   |    [-2] "rm -rf /tmp/BRANCH"                   <- cd_exec
   |    [-1] [["git tag 1 HEAD"]]
-  | The events reads go through git (git show) since the reads-via-git change,
-  | adding the two leading commands. The three cd_exec cleanup calls remain at
-  | positions -4, -3, -2 (counted from the end, so unaffected).
+  | The events reads go through git (git show), and main is advanced by an
+  | update-ref compare-and-swap rather than git merge --ff-only (no working-tree
+  | checkout). The three cd_exec cleanup calls remain at positions -4, -3, -2
+  | (counted from the end, so unaffected).
   ) do
     in_kata do |id|
       files   = kata_event(id, 0)['files']


### PR DESCRIPTION
  Now that reads go through git (#387-#389), nothing reads the main repo's working
  tree for current data, so the per-save working-tree checkout that
  git merge --ff-only performed is unnecessary. fast_forward_main_via_worktree
  (renamed from git_ff_merge_worktree, which no longer describes it) advances main
  with a git update-ref compare-and-swap:

      git update-ref refs/heads/main <branch> <branch>^

  This moves the ref without checking the new tree out, leaving the main working
  tree stale (harmless, since current-data reads go through git). The worktree
  branch is base + exactly one commit, so <branch>^ is the commit main was at when
  the worktree was created; the old-value precondition makes update-ref fail if a
  concurrent save advanced main since then, which the worktree_commit rescue maps
  to "Out of order event". This is the same loser-detection the non-ff merge gave.

  This removes the per-save working-tree checkout. Not benchmarked: the dominant
  per-save cost is git process startup, and the advance is one subprocess either
  way, so the saving is real mainly when events.json is large (long sessions) and
  may be a wash for small katas. The honest claim is "removes the checkout", not
  "measurably faster".

  Tests: Sp4DkG asserts a save leaves the working-tree events.json untouched while
  kata_events (via git) returns the new committed state. The concurrency suite
  (DccG02, Sp4DkC-F, Tn6Wb6/7) confirms the CAS still rejects losing concurrent
  saves as out-of-order. Comments, test docstrings, and docs/reads-via-git.md are
  swept to describe the update-ref mechanism rather than the old merge.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>