### PR TITLE
Read events.json once per save instead of twice

### DIFF
--- a/source/server/model/kata_v2.rb
+++ b/source/server/model/kata_v2.rb
@@ -108,8 +108,14 @@ class Kata_v2
   # - - - - - - - - - - - - - - - - - - - - - -
 
   def event(id, index)
+    event_from(id, index, events(id))
+  end
+
+  # Like event(id, index) but reuses an already-read events list, so callers
+  # that already have it (e.g. file_edit) don't trigger a second git show of
+  # events.json. See docs/reads-via-git.md.
+  def event_from(id, index, all_events)
     index = index.to_i
-    all_events = events(id)
 
     if index < 0
       pos_index = all_events.size + index
@@ -231,7 +237,7 @@ class Kata_v2
 
     all_events = events(id)
     last_index = all_events[-1]['index'] # all_events.size - 1
-    current_files = event(id, last_index)['files']
+    current_files = event_from(id, last_index, all_events)['files']
     edited_filename = edited_filename(current_files, files)
     if !edited_filename
       return index

--- a/test/server/config/coverage_metrics_limits.rb
+++ b/test/server/config/coverage_metrics_limits.rb
@@ -7,7 +7,7 @@ def metrics
     [ 'test.branches.total' , '<=', 8    ],
     [ 'test.branches.missed', '<=', 0    ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 1605 ],
+    [ 'code.lines.total'    , '<=', 1606 ],
     [ 'code.lines.missed'   , '<=', 0    ],
     [ 'code.branches.total' , '<=', 225  ],
     [ 'code.branches.missed', '<=', 0    ],

--- a/test/server/kata_worktree_cleanup.rb
+++ b/test/server/kata_worktree_cleanup.rb
@@ -27,8 +27,7 @@ class KataWorktreeCleanupTest < TestBase
   |
   | The spy records all shell commands issued during kata_ran_tests (with
   | unchanged files). The full sequence is:
-  |   [-14] ["git show HEAD:events.json"]          # file_edit -> events()
-  |   [-13] ["git show HEAD:events.json"]          # file_edit -> event() -> events()
+  |   [-13] ["git show HEAD:events.json"]          # file_edit -> events() (passed into event)
   |   [-12] ["git archive --format=tar 0"]         # file_edit -> event()
   |   [-11] ["git worktree add /tmp/BRANCH"]
   |   [-10] ["git rm -r files/"]
@@ -41,7 +40,8 @@ class KataWorktreeCleanupTest < TestBase
   |    [-3] "git branch --delete --force BRANCH"   <- cd_exec
   |    [-2] "rm -rf /tmp/BRANCH"                   <- cd_exec
   |    [-1] [["git tag 1 HEAD"]]
-  | The events reads go through git (git show), and main is advanced by an
+  | events.json is read via git once (file_edit reads it and passes it into
+  | event(), so there is no second git show), and main is advanced by an
   | update-ref compare-and-swap rather than git merge --ff-only (no working-tree
   | checkout). The three cd_exec cleanup calls remain at positions -4, -3, -2
   | (counted from the end, so unaffected).
@@ -58,10 +58,12 @@ class KataWorktreeCleanupTest < TestBase
       kata_ran_tests(id, 1, files, stdout, stderr, status, red_summary)
 
       # Pin the leading reads-via-git commands so the documented sequence
-      # cannot silently drift (e.g. an events read added or removed).
+      # cannot silently drift (e.g. an events read added or removed). file_edit
+      # reads events.json once and passes it into event(), so there is exactly
+      # one git show of events.json per save.
       assert_equal ["git show HEAD:events.json"],  spy.commands[0]
-      assert_equal ["git show HEAD:events.json"],  spy.commands[1]
-      assert_equal ["git archive --format=tar 0"], spy.commands[2]
+      assert_equal ["git archive --format=tar 0"], spy.commands[1]
+      assert_equal 1, spy.commands.count { |c| c == ["git show HEAD:events.json"] }
 
       branch = spy.commands[-4].split.last
       assert_equal "git worktree remove --force #{branch}", spy.commands[-4]


### PR DESCRIPTION
  A save's file_edit read the kata's events.json through git, then called
  event(last_index) which read events.json again. That is two git show
  subprocesses for the same HEAD events.json. Profiling a save showed each git
  invocation costs ~20ms of process startup (the dominant per-save cost), so a
  redundant one is pure overhead.

  Extract event_from(id, index, all_events) from event(id, index): event now calls
  it with events(id), and file_edit passes the all_events it already read, so the
  second git show is gone. Standalone event() / event_batch are unchanged (they
  still read events once, as needed). One fewer git subprocess per save.

  Hpq7Rz pins this: its recorded command sequence now has a single
  git show HEAD:events.json (commands[0]), git archive at commands[1], and an
  explicit assert that git show HEAD:events.json appears exactly once per save.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>