### PR TITLE
Parallelise the rugged compile to speed up the image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,10 @@ RUN apk add git jq
 # package, build, then drop it. Re-add libgcc for the libgcc_s the compiled
 # extension links at runtime (the only runtime lib not already provided by ruby;
 # libssl/libcrypto/libz/libgmp are).
+# rugged runs a bare gmake, so MAKEFLAGS=-j parallelises the libgit2 compile
+# (~3x faster: 142s -> 43s on a 10-core builder).
 RUN apk add --no-cache --virtual .rugged-build-deps build-base cmake pkgconf libgit2-dev \
- && gem install rugged \
+ && MAKEFLAGS="-j$(nproc)" gem install rugged \
  && apk del .rugged-build-deps \
  && apk add --no-cache libgcc
 


### PR DESCRIPTION
  rugged has no precompiled gem (all 113 published versions are source-only),
  so the saver image build compiles a vendored libgit2 from source. rugged
  invokes a bare gmake, leaving that compile single-threaded, which dominated
  build time - especially under the amd64-on-arm64 emulation local dev uses.

  Set MAKEFLAGS=-j$(nproc) for the gem install so the libgit2 build runs across
  all builder cores. Measured on a 10-core builder: the rugged compile drops
  from 142s to 43s (~3x), and a full make image_server completes in ~56s.

  $(nproc) is evaluated at build time, so CI's native amd64 runners parallelise
  across whatever cores they have too.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>