### PR TITLE
Trim historical framing from libgit2 git comments

### DIFF
--- a/source/server/external/git.rb
+++ b/source/server/external/git.rb
@@ -3,13 +3,14 @@ require 'json'
 
 module External
 
-  # In-process git reads via libgit2 (the rugged gem), avoiding a git subprocess
-  # (~20ms of process startup) per read. Used for the latest-committed-state
-  # reads (events.json, options.json) that currently shell out to
-  # "git show HEAD:<file>". See docs/in-process-git.md.
+  # In-process git reads via libgit2 (the rugged gem), avoiding a per-read git
+  # subprocess (~20ms of process startup). Used for the latest-committed-state
+  # reads (events.json, options.json). Equivalent to "git show HEAD:<file>".
+  # See docs/in-process-git.md.
   #
-  # PROTOTYPE: opens the repo per call. If that proves costly, cache the
-  # Rugged::Repository handle per repo_dir.
+  # Opens the repo per call rather than caching a Rugged::Repository handle
+  # per repo_dir. If that per-open cost proves significant, we could consider
+  # caching the handle.
   class Git
 
     # Raised when the numeric tag for an index is not present yet. A save writes
@@ -48,15 +49,16 @@ module External
     end
 
     # Full per-file diff of the files/ subtree between the commits tagged
-    # <was_index> (old) and <now_index> (new), in-process. Mirrors the old
+    # <was_index> (old) and <now_index> (new), in-process. Equivalent to
     # `git diff --unified=<all> --ignore-space-at-eol --find-renames
     #  <was> <now> -- files/`: it diffs the two files/ subtrees directly, so the
     # delta paths are already relative to files/ (no "files/" prefix) and rename
-    # detection is confined to files/, exactly as the "-- files/" pathspec did.
-    # Full context (one hunk per file) and ignore_whitespace_eol match the old
-    # flags (the latter is the closest libgit2 option to --ignore-space-at-eol;
-    # see docs/in-process-git.md); find_similar! restores git's default rename
-    # detection, which libgit2 does not do on its own. Returns an Array of plain
+    # detection is confined to files/, as the "-- files/" pathspec does. Full
+    # context (one hunk per file) and ignore_whitespace_eol give the same result
+    # as those flags (ignore_whitespace_eol is the closest libgit2 option to
+    # --ignore-space-at-eol; see docs/in-process-git.md); find_similar! restores
+    # git's default rename detection, which libgit2 does not do on its own.
+    # Returns an Array of plain
     # descriptors (no rugged objects leak), one per changed file:
     #   { status:, old_path:, new_path:,
     #     lines: [ { origin:, content:, old_lineno:, new_lineno: }, ... ] }
@@ -83,7 +85,7 @@ module External
     # { relpath => bytes } for every blob in the files/ subtree of the commit
     # tagged <index>, with relpath relative to files/ (no "files/" prefix). Lets
     # the diff endpoint list the kata's files and read their content at an index
-    # in-process, replacing `git ls-tree -- files/` and `git show <i>:files/<f>`.
+    # in-process. Equivalent to `git ls-tree -- files/` and `git show <i>:files/<f>`.
     # Raises TagNotFound if the tag is missing.
     def files_blobs(repo_dir, index)
       repo = Rugged::Repository.new(repo_dir)
@@ -141,16 +143,16 @@ module External
       Rugged::Repository.new(repo_dir).references.create("refs/tags/#{name}", oid)
     end
 
-    # Creates a kata's git repo in-process, replacing the shell batch
-    # (git init/config/add/commit/tag/branch). Initialises <repo_dir>, records
+    # Creates a kata's git repo in-process. Equivalent to the shell batch
+    # `git init/config/add/commit/tag/branch`. Initialises <repo_dir>, records
     # the committer identity in config (so later commits, which use the repo's
     # default_signature, work), commits <files> (a repo-relative path => content
     # map) as the parentless initial commit <message> on refs/heads/main, tags it
     # 0, and points HEAD at main. The identity is also passed explicitly to this
     # first commit so it does not depend on libgit2 having refreshed the config
-    # it was just handed. The result is an ordinary git repo, byte-identical to
-    # the old shell-built one, so the save/read and update-ref CAS paths run
-    # against it unchanged. Returns the commit oid. See docs/in-process-git.md.
+    # it was just handed. The result is an ordinary git repo, against which the
+    # save/read and update-ref CAS paths run unchanged. Returns the commit oid.
+    # See docs/in-process-git.md.
     def create(repo_dir, user_name, user_email, message, files)
       repo = Rugged::Repository.init_at(repo_dir)
       repo.config['user.name']  = user_name

--- a/source/server/model/git_diff_builder.rb
+++ b/source/server/model/git_diff_builder.rb
@@ -2,10 +2,9 @@ require_relative '../lib/utf8_clean'
 
 class GitDiffBuilder
   # Builds the saver's per-file diff hashes from the structured diff produced
-  # in-process by libgit2 (External::Git#diff). Replaces the old GitDiffParser,
-  # which parsed the textual output of the `git diff` command. The input is the
-  # Array of file descriptors External::Git#diff returns; the output matches the
-  # old parser's shape exactly (pinned by test/server/kata_diff.rb):
+  # in-process by libgit2 (External::Git#diff). The input is the Array of file
+  # descriptors External::Git#diff returns; the output shape is pinned by
+  # test/server/kata_diff.rb:
   #   { type:, old_filename:, new_filename:,
   #     line_counts: { added:, deleted:, same: }, lines? }
   # where :lines is present only when options[:lines] is truthy. A change region

--- a/source/server/model/kata_v2.rb
+++ b/source/server/model/kata_v2.rb
@@ -488,9 +488,9 @@ class Kata_v2
   # - - - - - - - - - - - - - - - - - - - - - -
 
   # Reads the kata git tree at the commit tagged pos_index, in-process via
-  # libgit2 (rugged), as { path => content }. (Formerly shelled out to
-  # "git archive --format=tar <index>"; the name is kept for now. See
-  # docs/in-process-git.md.)
+  # libgit2 (rugged), as { path => content }. Equivalent to
+  # "git archive --format=tar <index>" (hence the method name). See
+  # docs/in-process-git.md.
   #
   # A save commits its event (advancing main via git update-ref) and then, as a
   # separate step, writes that index's numeric tag (via rugged). A concurrent
@@ -544,8 +544,8 @@ class Kata_v2
     json_parse(Utf8.clean(git_show(id, 'options.json')))
   end
 
-  # Reads filename from the kata's git tree at HEAD as a string. Now in-process
-  # via libgit2 (rugged) instead of a "git show" subprocess. See
+  # Reads filename from the kata's git tree at HEAD as a string, in-process via
+  # libgit2 (rugged). Equivalent to "git show HEAD:<filename>". See
   # docs/in-process-git.md.
   def git_show(id, filename)
     git.head_blob(repo_dir(id), filename)


### PR DESCRIPTION
  The "we used to shell out, which was inferior" narration is noise now
  that the migration has landed (the story lives in git history and
  docs/in-process-git.md). Replace it with terse "Equivalent to <git
  command>" notes that tell a reader what each rugged call does at a
  glance. Kept the comments explaining why the update-ref CAS stays a
  shell call, and the message-format/Utf8.clean behavioural notes. Also
  dropped the stale PROTOTYPE label now the code has shipped.