### PR TITLE
Run saver as its own docker-compose project so it does not collide

### DIFF
--- a/bin/create_almost_full_group.sh
+++ b/bin/create_almost_full_group.sh
@@ -8,11 +8,17 @@ source "${ROOT_DIR}/bin/echo_env_vars.sh"
 readonly VERSION="${1}"  # {0|1|2}
 # shellcheck disable=SC2046
 export $(echo_env_vars)
-readonly CONTAINER="${CYBER_DOJO_SAVER_SERVER_CONTAINER_NAME}"
+
+# Run as our own docker-compose project so this repo's containers, and
+# those of sibling repos, can run at once without colliding on fixed
+# container names.
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-saver}"
 readonly USER="${CYBER_DOJO_SAVER_SERVER_USER}"
 
 # TODO: Need to start a custom-start-points container
 docker --log-level=ERROR compose --progress=plain up --no-build --wait --wait-timeout=10 server
+# Resolved after compose up because the container does not exist before it.
+readonly CONTAINER="$(service_container server)"
 docker exec "${CONTAINER}" bash -c "rm -rf /cyber-dojo/*"
 readonly GID=$(docker exec --user "${USER}" "${CONTAINER}" bash -c "ruby /saver/test/data/create_almost_full_group.rb ${VERSION}")
 

--- a/bin/echo_env_vars.sh
+++ b/bin/echo_env_vars.sh
@@ -22,9 +22,6 @@ echo_env_vars()
   echo CYBER_DOJO_SAVER_SERVER_USER=saver
   echo CYBER_DOJO_SAVER_CLIENT_USER=nobody
 
-  echo CYBER_DOJO_SAVER_SERVER_CONTAINER_NAME=test_saver_server
-  echo CYBER_DOJO_SAVER_CLIENT_CONTAINER_NAME=test_saver_client
-  
   # This repo overrides
   local -r AWS_ACCOUNT_ID=244531986313
   local -r AWS_REGION=eu-central-1

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -45,6 +45,21 @@ installed()
   fi
 }
 
+service_container()
+{
+  # Echo the container id of the given docker-compose service within
+  # this repo's project. The project is COMPOSE_PROJECT_NAME (set by the
+  # entry scripts), defaulting to saver so the helpers work against a
+  # plain run when the var is not exported in the shell. Resolving by
+  # label (rather than a fixed container_name) lets several saver runs,
+  # and runs in sibling repos, coexist without colliding.
+  local -r service="${1}"
+  docker ps \
+    --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME:-saver}" \
+    --filter "label=com.docker.compose.service=${service}" \
+    --format '{{.ID}}'
+}
+
 create_space_limited_volume()
 {
   docker volume create --driver local \
@@ -58,7 +73,7 @@ create_space_limited_volume()
 copy_in_saver_test_data()
 {
   local -r TEST_DATA_DIR="${ROOT_DIR}/test/server/data"
-  local -r CID="${CYBER_DOJO_SAVER_SERVER_CONTAINER_NAME}"
+  local -r CID="$(service_container server)"
   # You cannot docker cp to a tmpfs, so tar-piping...
 
   if [ "${CI:-}" == 'true' ]; then

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -5,6 +5,12 @@ export ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${ROOT_DIR}/bin/lib.sh"
 source "${ROOT_DIR}/bin/echo_env_vars.sh"
 
+# Run as our own docker-compose project so this repo's containers, and
+# those of sibling repos, can run at once without colliding on fixed
+# container names. Override to run a second saver alongside the first,
+# eg: COMPOSE_PROJECT_NAME=saver2 bin/run_tests.sh server
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-saver}"
+
 show_help()
 {
     local -r MY_NAME=$(basename "${BASH_SOURCE[0]}")
@@ -30,12 +36,10 @@ check_args()
     'server')
       export TYPE=server
       export USER="${CYBER_DOJO_SAVER_SERVER_USER}"
-      export CONTAINER_NAME="${CYBER_DOJO_SAVER_SERVER_CONTAINER_NAME}"
       ;;
     'client')
       export TYPE=client
       export USER="${CYBER_DOJO_SAVER_CLIENT_USER}"
-      export CONTAINER_NAME="${CYBER_DOJO_SAVER_CLIENT_CONTAINER_NAME}"
       ;;
     '')
       show_help
@@ -106,6 +110,9 @@ run_tests()
   containers_down
   create_space_limited_volume
   docker --log-level=ERROR compose --progress=plain up --no-build --wait --wait-timeout=10 "${TYPE}"
+  # Resolved here (not in check_args) because the container does not exist
+  # until the compose up above has brought it up.
+  export CONTAINER_NAME="$(service_container "${TYPE}")"
   echo_warnings "${TYPE}"
   copy_in_saver_test_data
   run_tests_in_container "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
         - COMMIT_SHA
     image: ${CYBER_DOJO_SAVER_CLIENT_IMAGE}:${CYBER_DOJO_SAVER_TAG}
     user: ${CYBER_DOJO_SAVER_CLIENT_USER}
-    container_name: ${CYBER_DOJO_SAVER_CLIENT_CONTAINER_NAME}
     env_file: [ .env ]
     read_only: true
     restart: no
@@ -32,7 +31,6 @@ services:
         - COMMIT_SHA
     image: ${CYBER_DOJO_SAVER_IMAGE}:${CYBER_DOJO_SAVER_TAG}
     user: ${CYBER_DOJO_SAVER_SERVER_USER}
-    container_name: ${CYBER_DOJO_SAVER_SERVER_CONTAINER_NAME}
     env_file: [ .env ]
     read_only: true
     restart: no
@@ -48,7 +46,6 @@ services:
     platform: linux/amd64
     image: ${CYBER_DOJO_DIFFER_IMAGE}:${CYBER_DOJO_DIFFER_TAG}
     user: nobody
-    ports: [ "${CYBER_DOJO_DIFFER_PORT}:${CYBER_DOJO_DIFFER_PORT}" ]
     env_file: [ .env ]
     environment:
       - CYBER_DOJO_SAVER_HOSTNAME=server


### PR DESCRIPTION
    saver brought its stack up under fixed per-service container names
    (test_saver_server, test_saver_client) and published the differ port
    on the host. So a saver run could not coexist with a run in a sibling
    repo, nor with a second saver run: they fought over the same container
    names and host port.

    Make saver its own docker-compose project instead, mirroring the same
    change in the web repo:
    - Drop the per-service container_name so Compose namespaces containers by project (COMPOSE_PROJECT_NAME, default saver). Override it to run a second saver alongside the first.
    - Stop publishing the differ port to the host. The server reaches differ over the project's private network by service name, so no host port is needed and nothing else collides.

    Container references in the helper scripts no longer assume fixed
    names; they resolve by compose project+service label via a shared
    service_container() in lib.sh, called after compose up since the
    container does not exist before then.

    Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>