### PR TITLE
Make capture_stdout_stderr thread-safe under concurrent tests

### DIFF
--- a/test/server/capture_stdout_stderr.rb
+++ b/test/server/capture_stdout_stderr.rb
@@ -8,8 +8,11 @@ module CaptureStdoutStderr
       old_stderr_stream = Thread.current[:stderr_stream]
       captured_stdout = StringIO.new(+'', 'w')
       captured_stderr = StringIO.new(+'', 'w')
-      $stdout = captured_stdout
-      $stderr = captured_stderr
+      # Set only the per-thread streams, never the process-global $stdout/$stderr.
+      # Swapping the global is not thread-safe: under Minitest's concurrent test
+      # execution another thread's write would land in this thread's buffer.
+      # Production logging reads Thread.current[:stdout_stream] via the
+      # stdout_stream/stderr_stream accessors, so per-thread capture suffices.
       Thread.current[:stdout_stream] = captured_stdout
       Thread.current[:stderr_stream] = captured_stderr
       yield uncaptured_stdout, uncaptured_stderr
@@ -17,8 +20,6 @@ module CaptureStdoutStderr
     ensure
       Thread.current[:stdout_stream] = old_stdout_stream
       Thread.current[:stderr_stream] = old_stderr_stream
-      $stdout = uncaptured_stdout
-      $stderr = uncaptured_stderr
     end
   end
 

--- a/test/server/capture_stdout_stderr_test.rb
+++ b/test/server/capture_stdout_stderr_test.rb
@@ -1,0 +1,30 @@
+require_relative 'test_base'
+
+class CaptureStdoutStderrTest < TestBase
+
+  test 'Cs7f01', %w(
+  | capture_stdout_stderr must capture via the per-thread stream WITHOUT
+  | swapping the process-global $stdout/$stderr.
+  | Swapping the global makes the helper unsafe under Minitest's concurrent
+  | test execution: a write from another thread lands in this thread's
+  | captured buffer (cross-test stdout bleed).
+  ) do
+    outer_stdout = $stdout
+    outer_stderr = $stderr
+    inner_stdout = nil
+    inner_stderr = nil
+    captured_stdout, captured_stderr = capture_stdout_stderr do
+      inner_stdout = $stdout
+      inner_stderr = $stderr
+      Thread.current[:stdout_stream].print('hello-out')
+      Thread.current[:stderr_stream].print('hello-err')
+    end
+    # capture still works, via the per-thread stream
+    assert_equal 'hello-out', captured_stdout, :captured_stdout
+    assert_equal 'hello-err', captured_stderr, :captured_stderr
+    # but the process-global streams must be left untouched (thread-safety)
+    assert_same outer_stdout, inner_stdout, :global_stdout_not_swapped
+    assert_same outer_stderr, inner_stderr, :global_stderr_not_swapped
+  end
+
+end

--- a/test/server/config/coverage_metrics_limits.rb
+++ b/test/server/config/coverage_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 2860 ],
+    [ 'test.lines.total'    , '<=', 2872 ],
     [ 'test.lines.missed'   , '<=', 0    ],
     [ 'test.branches.total' , '<=', 4    ],
     [ 'test.branches.missed', '<=', 0    ],

--- a/test/server/config/test_metrics_limits.rb
+++ b/test/server/config/test_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test_count',    '>=', 340 ],
+    [ 'test_count',    '>=', 341 ],
     [ 'total_time',    '<=',  50 ],
     [ nil ],
     [ 'failure_count', '<=', 0   ],


### PR DESCRIPTION
  capture_stdout_stderr swapped the process-global $stdout/$stderr for the
  duration of the block. Minitest runs tests concurrently, so that global
  swap is shared across threads: output a concurrent test logs (for example
  a caught server-side exception) can land in a different test's captured
  buffer. That made a passing test fail on an unrelated stdout assertion,
  mis-attributing one test's error to another.

  Set only the per-thread streams (Thread.current[:stdout_stream/stderr_stream])
  and never touch the global $stdout/$stderr. Production logging already reads
  the per-thread stream via the stdout_stream/stderr_stream accessors, so
  per-thread capture still captures everything while staying isolated between
  concurrently-running tests.

  Add a test pinning the property: capture works via the per-thread stream
  without mutating the global $stdout/$stderr.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>