### PR TITLE
Add cluster: the saver foundation for a multi-LTF practice

### DIFF
--- a/source/server/app.rb
+++ b/source/server/app.rb
@@ -12,8 +12,8 @@ class App < AppBase
 
   # - - - - - - - - - - - - - - - - -
 
-   get_json(:model, :diff_lines)
-   get_json(:model, :diff_summary)
+  post_json(:model, :cluster_create)
+   get_json(:model, :cluster_manifest)
 
   # - - - - - - - - - - - - - - - - -
 
@@ -46,5 +46,8 @@ class App < AppBase
   post_json(:model, :kata_reverted)
   post_json(:model, :kata_checked_out)
   post_json(:model, :kata_option_set)
+
+   get_json(:model, :diff_lines)
+   get_json(:model, :diff_summary)
 
 end

--- a/source/server/model.rb
+++ b/source/server/model.rb
@@ -6,6 +6,7 @@ require_relative 'model/group_v2'
 require_relative 'model/kata_v0'
 require_relative 'model/kata_v1'
 require_relative 'model/kata_v2'
+require_relative 'model/cluster'
 
 class Model
 
@@ -28,6 +29,42 @@ class Model
 
   def group_manifest(id:)
     group(id).manifest(id)
+  end
+
+  def cluster_create(manifest:)
+    Cluster.new(@externals).create(manifest)
+  end
+
+  def cluster_manifest(id:)
+    Cluster.new(@externals).manifest(id)
+  end
+
+  # True if a cluster with this id exists.
+  def cluster_exists?(id:)
+    unless id?(id)
+      return false
+    end
+    disk.run(disk.dir_exists_command(cluster_id_path(id)))
+  end
+
+  # The id-chain from the given entity up to the topmost one, ordered
+  # bottom-to-top as [{type,id}, ...]; eg a kata in a cluster returns
+  # [{kata},{group},{cluster}]. The top id is the last entry's id. Each step
+  # appends its entry and advances id to its parent (group_id, then cluster_id).
+  def id_hierarchy(id:)
+    result = []
+    if kata_exists?(id:id)
+      result << { 'type' => 'kata', 'id' => id }
+      id = kata_manifest(id:id)['group_id']
+    end
+    if group_exists?(id:id)
+      result << { 'type' => 'group', 'id' => id }
+      id = group_manifest(id:id)['cluster_id']
+    end
+    if cluster_exists?(id:id)
+      result << { 'type' => 'cluster', 'id' => id }
+    end
+    result
   end
 
   def group_join(id:, indexes:AVATAR_INDEXES.shuffle)

--- a/source/server/model/cluster.rb
+++ b/source/server/model/cluster.rb
@@ -1,0 +1,76 @@
+require_relative 'group_v2'
+require_relative 'id_generator'
+require_relative 'id_pather'
+require_relative '../request_error'
+require_relative '../lib/json_adapter'
+
+# A cluster is the umbrella over a multi-LTF practice. It holds the group-wide
+# exercise and references its child groups (one ordinary Group_v2 per LTF). It
+# is NOT a group and is never joined directly; joining resolves to a child group.
+class Cluster
+
+  # Stores the externals (disk, time, random, ...) used to persist the cluster.
+  def initialize(externals)
+    @externals = externals
+  end
+
+  # Creates the cluster: generates its id, creates one Group_v2 child per ltf
+  # (each carrying cluster_id), stores the cluster referencing the children, and
+  # returns the cluster id. A cluster offers 2..4 LTFs (a single-LTF practice is a
+  # bare Group_v2, not a cluster), so any other ltfs.size raises RequestError.
+  def create(manifest)
+    ltfs = manifest.fetch('ltfs')
+    unless (2..4).include?(ltfs.size)
+      fail RequestError, "ltfs.size:#{ltfs.size}: (a cluster offers 2..4 LTFs)"
+    end
+    id = IdGenerator.new(@externals).cluster_id
+    children = ltfs.map do |ltf|
+      group_id = Group_v2.new(@externals).create(ltf.merge('cluster_id' => id))
+      { 'ltf_display_name' => ltf['display_name'], 'group_id' => group_id }
+    end
+    disk.assert(manifest_create_command(id, json_plain({
+      'id'       => id,
+      'created'  => time.now,
+      'exercise' => manifest['exercise'],
+      'children' => children
+    })))
+    id
+  end
+
+  # Returns the cluster's stored manifest (exercise + children).
+  def manifest(id)
+    json_parse(disk.assert(manifest_read_command(id)))
+  end
+
+  private
+
+  include IdPather
+  include JsonAdapter
+
+  # Command that writes the cluster's manifest.json.
+  def manifest_create_command(id, src)
+    disk.file_create_command(manifest_filename(id), src)
+  end
+
+  # Command that reads the cluster's manifest.json.
+  def manifest_read_command(id)
+    disk.file_read_command(manifest_filename(id))
+  end
+
+  # Absolute path of the cluster's manifest.json, eg
+  # /cyber-dojo/clusters/wA/tC/fj/manifest.json
+  def manifest_filename(id)
+    cluster_id_path(id, 'manifest.json')
+  end
+
+  # The disk service.
+  def disk
+    @externals.disk
+  end
+
+  # The time service.
+  def time
+    @externals.time
+  end
+
+end

--- a/source/server/model/id_generator.rb
+++ b/source/server/model/id_generator.rb
@@ -21,11 +21,15 @@ class IdGenerator
   end
 
   def group_id
-    generate_id(:group_id_path, :kata_id_path)
+    generate_id(:group_id_path, :kata_id_path, :cluster_id_path)
   end
 
   def kata_id
-    generate_id(:kata_id_path, :group_id_path)
+    generate_id(:kata_id_path, :group_id_path, :cluster_id_path)
+  end
+
+  def cluster_id
+    generate_id(:cluster_id_path, :group_id_path, :kata_id_path)
   end
 
   private
@@ -34,15 +38,14 @@ class IdGenerator
 
   include IdPather
 
-  def generate_id(pather, not_pather)
+  def generate_id(pather, *not_pathers)
     256.times.find do
       id = SIZE.times.map{ ALPHABET[random_index] }.join
       if reserved?(id)
         next
       end
-      # Ensure group IDs and kata IDs do not clash with each other
-      dir_exists_command = disk.dir_exists_command(method(not_pather).call(id))
-      if disk.run(dir_exists_command)
+      # Ensure ids do not clash across groups, katas and clusters.
+      if not_pathers.any? { |np| disk.run(disk.dir_exists_command(method(np).call(id))) }
         next
       end
 

--- a/source/server/model/id_pather.rb
+++ b/source/server/model/id_pather.rb
@@ -8,6 +8,10 @@ module IdPather
     id_path3('katas', id, *parts)
   end
 
+  def cluster_id_path(id, *parts)
+    id_path3('clusters', id, *parts)
+  end
+
   def id_path3(type, id, *parts)
     # Using 2/2/2 split.
     # See https://github.com/cyber-dojo-tools/id-split-timer

--- a/test/server/cluster_create.rb
+++ b/test/server/cluster_create.rb
@@ -1,0 +1,68 @@
+require_relative 'test_base'
+
+class ClusterCreateTest < TestBase
+
+  test 'Cl9a30', %w(
+  | POST /cluster_create(manifest) creates one child group per ltf (each an
+  | ordinary Group_v2 carrying cluster_id) and stores a cluster referencing them;
+  | round-trips exercise + children via cluster_manifest
+  ) do
+    manifest = {
+      'exercise' => 'Tennis',
+      'ltfs' => [
+        manifest_Tennis_refactoring_Python_unitttest,
+        manifest_Tennis_refactoring_Ruby_minitest
+      ]
+    }
+    assert_json_post_200(
+      path = 'cluster_create',
+      { manifest:manifest }.to_json
+    ) do |response|
+      id = response[path]
+      cluster = cluster_manifest(id)
+      assert_equal 'Tennis', cluster['exercise'], :exercise
+      assert_equal ['Tennis refactoring, Python unitttest',
+                    'Tennis refactoring, Ruby minitest'],
+                   cluster['children'].map { |c| c['ltf_display_name'] }, :ltf_display_names
+      cluster['children'].each do |c|
+        assert group_exists?(c['group_id']), c['group_id']
+        assert_equal id, group_manifest(c['group_id'])['cluster_id'], :cluster_id
+      end
+    end
+  end
+
+  test 'Cl9a31', %w(
+  | POST /cluster_create(manifest) with only one ltf is a 400
+  | a single-LTF practice is a bare Group_v2, not a cluster
+  ) do
+    manifest = {
+      'exercise' => 'Tennis',
+      'ltfs' => [ manifest_Tennis_refactoring_Python_unitttest ]
+    }
+    capture_stdout_stderr {
+      post_json '/cluster_create', { manifest:manifest }.to_json
+    }
+    assert_equal 400, last_response.status
+  end
+
+  test 'Cl9a32', %w(
+  | POST /cluster_create(manifest) with more than 4 ltfs is a 400
+  | a cluster offers at most 4 LTFs
+  ) do
+    manifest = {
+      'exercise' => 'Tennis',
+      'ltfs' => [
+        { 'display_name' => 'C, assert' },
+        { 'display_name' => 'Java, JUnit' },
+        { 'display_name' => 'Go, testing' },
+        { 'display_name' => 'Python, unittest' },
+        { 'display_name' => 'Ruby, minitest' }
+      ]
+    }
+    capture_stdout_stderr {
+      post_json '/cluster_create', { manifest:manifest }.to_json
+    }
+    assert_equal 400, last_response.status
+  end
+
+end

--- a/test/server/config/coverage_metrics_limits.rb
+++ b/test/server/config/coverage_metrics_limits.rb
@@ -2,14 +2,14 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 2872 ],
+    [ 'test.lines.total'    , '<=', 2952 ],
     [ 'test.lines.missed'   , '<=', 0    ],
     [ 'test.branches.total' , '<=', 4    ],
     [ 'test.branches.missed', '<=', 0    ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 1563 ],
+    [ 'code.lines.total'    , '<=', 1621 ],
     [ 'code.lines.missed'   , '<=', 0    ],
-    [ 'code.branches.total' , '<=', 187  ],
+    [ 'code.branches.total' , '<=', 197  ],
     [ 'code.branches.missed', '<=', 0    ],
   ]
 end

--- a/test/server/config/test_metrics_limits.rb
+++ b/test/server/config/test_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test_count',    '>=', 341 ],
+    [ 'test_count',    '>=', 357 ],
     [ 'total_time',    '<=',  50 ],
     [ nil ],
     [ 'failure_count', '<=', 0   ],

--- a/test/server/data/kata_test_data.rb
+++ b/test/server/data/kata_test_data.rb
@@ -147,6 +147,28 @@ module KataTestData
     }
   end
 
+  def manifest_Tennis_refactoring_Ruby_minitest
+    {
+      'display_name' => 'Tennis refactoring, Ruby minitest',
+      'filename_extension' => ['.rb'],
+      'image_name' => 'cyberdojofoundation/ruby_mini_test',
+      'visible_files' => {
+        'cyber-dojo.sh' => {
+          'content' => "ruby tennis_test.rb\n"
+        },
+        'readme.txt' => {
+          'content' => "Tennis has a rather quirky scoring system, and to newcomers it\ncan be a little difficult to keep track of. The local tennis club\nhas some code that is currently being used to update the scoreboard\nwhen a player scores a point.\n \nYour job is to refactor the code until you are happy to work with it.\nThe future is uncertain, new features may be needed, and you want to\nbe thoroughly on top of your game when that happens.\n \nSummary of Tennis scoring:\n1. A game is won by the first player to have won at least four points\n   in total and at least two points more than the opponent.\n2. The running score of each game is described in a manner peculiar\n   to tennis: scores from zero to three points are described as 'love',\n   'fifteen', 'thirty', and 'forty' respectively.\n3. If at least three points have been scored by each player, and the\n   scores are equal, the score is 'deuce'.\n4. If at least three points have been scored by each side and a player\n   has one more point than the opponent, the score of the game is\n   'advantage' for the player in the lead."
+        },
+        'tennis.rb' => {
+          'content' => "class TennisGame1\n  POINT_NAMES = %w(Love Fifteen Thirty Forty).freeze\n\n  def initialize(player1_name, player2_name)\n    @player1_name = player1_name\n    @player2_name = player2_name\n    @p1points = 0\n    @p2points = 0\n  end\n\n  def won_point(player_name)\n    if player_name == @player1_name\n      @p1points += 1\n    else\n      @p2points += 1\n    end\n  end\n\n  def score\n    if @p1points == @p2points\n      tied_score\n    elsif @p1points >= 4 || @p2points >= 4\n      end_game_score\n    else\n      running_score\n    end\n  end\n\n  private\n\n  def tied_score\n    return 'Deuce' if @p1points >= 3\n    POINT_NAMES[@p1points] + '-All'\n  end\n\n  def end_game_score\n    lead = @p1points - @p2points\n    leader = lead > 0 ? @player1_name : @player2_name\n    lead.abs == 1 ? 'Advantage ' + leader : 'Win for ' + leader\n  end\n\n  def running_score\n    POINT_NAMES[@p1points] + '-' + POINT_NAMES[@p2points]\n  end\nend\n"
+        },
+        'tennis_test.rb' => {
+          'content' => "require 'minitest/autorun'\nrequire_relative 'tennis'\n\nclass TennisTest < Minitest::Test\n  TEST_CASES = [\n    [0, 0, 'Love-All'],\n    [1, 1, 'Fifteen-All'],\n    [2, 2, 'Thirty-All'],\n    [3, 3, 'Deuce'],\n    [4, 4, 'Deuce'],\n    [1, 0, 'Fifteen-Love'],\n    [0, 1, 'Love-Fifteen'],\n    [4, 0, 'Win for player1'],\n    [0, 4, 'Win for player2'],\n    [4, 3, 'Advantage player1'],\n    [3, 4, 'Advantage player2'],\n  ].freeze\n\n  def play_game(p1_points, p2_points)\n    game = TennisGame1.new('player1', 'player2')\n    [p1_points, p2_points].max.times do |i|\n      game.won_point('player1') if i < p1_points\n      game.won_point('player2') if i < p2_points\n    end\n    game\n  end\n\n  def test_score\n    TEST_CASES.each do |p1_points, p2_points, expected|\n      game = play_game(p1_points, p2_points)\n      assert_equal expected, game.score\n    end\n  end\nend\n"
+        }
+      }
+    }.clone
+  end
+
   def manifest_Tennis_refactoring_Python_unitttest
     {
       'display_name' => 'Tennis refactoring, Python unitttest',

--- a/test/server/helpers/model.rb
+++ b/test/server/helpers/model.rb
@@ -28,6 +28,18 @@ module TestHelpersModel
     model.group_fork(id:id, index:index)
   end
 
+  def cluster_create(manifest)
+    model.cluster_create(manifest:manifest)
+  end
+
+  def id_hierarchy(id)
+    model.id_hierarchy(id:id)
+  end
+
+  def cluster_manifest(id)
+    model.cluster_manifest(id:id)
+  end
+
   AVATAR_INDEXES = (0..63).to_a
 
   # - - - - - - - - - - - - - - -

--- a/test/server/id_generation.rb
+++ b/test/server/id_generation.rb
@@ -97,6 +97,38 @@ class IdGenerationTest < TestBase
 
   # - - - - - - - - - - - - - - - - - - -
 
+  test 'A6D14g', %w(
+  | kata-id generator will skip an id that already exists as a cluster
+  ) do
+    cluster_id = cluster_create(
+      'exercise' => 'Tennis',
+      'ltfs' => [
+        manifest_Tennis_refactoring_Python_unitttest,
+        manifest_Tennis_refactoring_Ruby_minitest
+      ]
+    )
+    id = 'kP4mR9'
+    id_generator = stubbed_id_generator(cluster_id + id)
+    assert_equal id, id_generator.kata_id
+  end
+
+  test 'A6D14h', %w(
+  | group-id generator will skip an id that already exists as a cluster
+  ) do
+    cluster_id = cluster_create(
+      'exercise' => 'Tennis',
+      'ltfs' => [
+        manifest_Tennis_refactoring_Python_unitttest,
+        manifest_Tennis_refactoring_Ruby_minitest
+      ]
+    )
+    id = 'gT7wQ2'
+    id_generator = stubbed_id_generator(cluster_id + id)
+    assert_equal id, id_generator.group_id
+  end
+
+  # - - - - - - - - - - - - - - - - - - -
+
   test 'A6D068', %w(
   | id?(s) true examples
   ) do

--- a/test/server/id_hierarchy.rb
+++ b/test/server/id_hierarchy.rb
@@ -1,0 +1,78 @@
+require_relative 'test_base'
+
+class IdHierarchyTest < TestBase
+
+  def two_ltf_cluster
+    cluster_create('exercise' => 'Tennis', 'ltfs' => [
+      manifest_Tennis_refactoring_Python_unitttest,
+      manifest_Tennis_refactoring_Ruby_minitest ])
+  end
+
+  test 'Hy1a01', %w( | solo kata -> [kata] ) do
+    in_kata do |kata_id|
+      assert_equal([{ 'type' => 'kata', 'id' => kata_id }], id_hierarchy(kata_id))
+    end
+  end
+
+  test 'Hy1a02', %w( | kata in a bare group -> [kata, group] ) do
+    in_group do |group_id|
+      kata_id = group_join(group_id)
+      assert_equal([{ 'type' => 'kata',  'id' => kata_id },
+                    { 'type' => 'group', 'id' => group_id }], id_hierarchy(kata_id))
+    end
+  end
+
+  test 'Hy1a03', %w( | kata in a cluster -> [kata, group, cluster] ) do
+    cluster_id = two_ltf_cluster
+    group_id = cluster_manifest(cluster_id)['children'].first['group_id']
+    kata_id = group_join(group_id)
+    assert_equal([{ 'type' => 'kata',    'id' => kata_id },
+                  { 'type' => 'group',   'id' => group_id },
+                  { 'type' => 'cluster', 'id' => cluster_id }], id_hierarchy(kata_id))
+  end
+
+  test 'Hy1a04', %w( | bare group -> [group] ) do
+    in_group do |group_id|
+      assert_equal([{ 'type' => 'group', 'id' => group_id }], id_hierarchy(group_id))
+    end
+  end
+
+  test 'Hy1a05', %w( | group in a cluster -> [group, cluster] ) do
+    cluster_id = two_ltf_cluster
+    group_id = cluster_manifest(cluster_id)['children'].first['group_id']
+    assert_equal([{ 'type' => 'group',   'id' => group_id },
+                  { 'type' => 'cluster', 'id' => cluster_id }], id_hierarchy(group_id))
+  end
+
+  test 'Hy1a06', %w( | cluster -> [cluster] ) do
+    cluster_id = two_ltf_cluster
+    assert_equal([{ 'type' => 'cluster', 'id' => cluster_id }], id_hierarchy(cluster_id))
+  end
+
+  versions_01_test 'Hy1a07', %w(
+  | a v0/v1 kata in a group -> [kata, group] (no cluster)
+  ) do
+    katas  = { 0 => 'k5ZTk0', 1 => 'rUqcey' }
+    groups = { 0 => 'chy6BJ', 1 => 'LyQpFr' }
+    kata_id  = katas[version]
+    group_id = groups[version]
+    assert_equal([{ 'type' => 'kata',  'id' => kata_id },
+                  { 'type' => 'group', 'id' => group_id }], id_hierarchy(kata_id))
+  end
+
+  versions_01_test 'Hy1a08', %w(
+  | a v0/v1 bare group -> [group] (no cluster)
+  ) do
+    groups = { 0 => 'FxWwrr', 1 => 'REf1t8' }
+    group_id = groups[version]
+    assert_equal([{ 'type' => 'group', 'id' => group_id }], id_hierarchy(group_id))
+  end
+
+  test 'Hy1a09', %w(
+  | a v1 solo kata (not in a group) -> [kata]
+  ) do
+    kata_id = 'H8NAvN'
+    assert_equal([{ 'type' => 'kata', 'id' => kata_id }], id_hierarchy(kata_id))
+  end
+
+end


### PR DESCRIPTION
  A group practice should be able to offer up to 4 language-test-frameworks.
  Rather than overloading a group, a multi-LTF practice is modelled as a
  "cluster": an umbrella over N (2..4) ordinary single-LTF Group_v2 children,
  one per LTF. This keeps the existing group/kata code untouched - the cluster
  is a separate top-level entity, never joined directly.

  Saver foundation:
  - Cluster model + cluster_create / cluster_manifest endpoints. cluster_create generates the cluster id, creates one Group_v2 child per ltf (each carrying a cluster_id parent pointer), and stores the cluster referencing them. A cluster offers 2..4 LTFs, so any other ltfs.size is a 400 (RequestError).
  - cluster_exists?, and a clusters/ path + cluster_id generation. group_id / kata_id / cluster_id now mutually exclude each other so ids are unique across all three (an entered id resolves unambiguously).
  - id_hierarchy(id): walks parent pointers (kata.group_id -> group.cluster_id) and returns the chain from the given id up to the topmost entity, ordered bottom-to-top as [{type,id}, ...]. The dashboard/web use it to resolve any id (kata, group or cluster) up to the practice it belongs to.

  Tests cover cluster_create (round-trip, 2..4 bounds), id uniqueness across
  groups/katas/clusters, and id_hierarchy for v2 (all shapes) and v0/v1
  (kata-in-group, bare group, solo kata). Bump the metrics limits for the new
  code and tests.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>