### PR TITLE
Expose cluster_exists? and cluster_hierarchy over HTTP; rename id_hie…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ $ make {metrics_coverage_server|metrics_coverage_client}
 
 # API
 
+## [Cluster API](docs/api.md#cluster-api)
+
+* [POST cluster_create(manifest)](docs/api.md#post-cluster_createmanifest)
+* [GET cluster_manifest(id)](docs/api.md#get-cluster_manifestid)
+* [GET cluster_exists?(id)](docs/api.md#get-cluster_existsid)
+* [GET cluster_hierarchy(id)](docs/api.md#get-cluster_hierarchyid)
+
 ## [Group API](docs/api.md#group-api)
 
 * [POST group_create(manifest)](docs/api.md#post-group_createmanifest)

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,131 @@
 
 
 - - - -
+# Cluster API
+
+A cluster is the umbrella over a multi-LTF practice: it offers 2..4
+language-test-frameworks, holding one ordinary group per LTF (its children).
+A cluster is never joined directly; a joiner joins one of its child groups.
+
+## POST cluster_create(manifest)
+Creates a cluster from the given `manifest` and returns its id.
+The manifest holds the group-wide `exercise` and an `ltfs` array (2..4 per-LTF
+group manifests). For each ltf a child group is created, carrying a `cluster_id`
+back-pointer, and the cluster references the children.
+- parameters
+  * **manifest:Hash** with `exercise:String` and `ltfs:Array[Hash]`, the 2..4
+    per-LTF group manifests (as built by
+    [creator](https://github.com/cyber-dojo/creator)).
+- returns
+  * the `id` of the created cluster.
+  * status 400 if `ltfs` does not hold 2..4 entries.
+- example
+  ```bash
+  $ curl \
+    --data '{"manifest":{"exercise":"Tennis","ltfs":[...]}}' \
+    --fail \
+    --header 'Content-type: application/json' \
+    --silent \
+    --request POST \
+      https://${DOMAIN}:${PORT}/cluster_create | jq .
+  ```
+  ```bash
+  {
+    "cluster_create": "dFg8Us"
+  }
+  ```
+
+
+- - - -
+## GET cluster_manifest(id)
+Gets the manifest of the cluster with the given `id`: its `exercise` and its
+`children` (one per LTF, each `{ltf_display_name, group_id}`).
+- parameters
+  * **id:String**. The cluster id.
+- returns
+  * the manifest of the cluster with the given `id`.
+- example
+  ```bash
+  $ curl \
+    --data '{"id":"dFg8Us"}' \
+    --fail \
+    --header 'Content-type: application/json' \
+    --silent \
+    --request GET \
+      https://${DOMAIN}:${PORT}/cluster_manifest | jq .
+  ```
+  ```bash
+  {
+    "cluster_manifest": {
+      "id": "dFg8Us",
+      "exercise": "Tennis",
+      "children": [
+        { "ltf_display_name": "Python, unittest", "group_id": "g1AbCd" },
+        { "ltf_display_name": "Ruby, MiniTest",   "group_id": "g2EfGh" }
+      ]
+    }
+  }
+  ```
+
+
+- - - -
+## GET cluster_exists?(id)
+Determines if a cluster with the given `id` exists.
+- parameters
+  * **id:String**. The cluster id.
+- returns
+  * `true` if a cluster with the given `id` exists, otherwise `false`.
+- example
+  ```bash
+  $ curl \
+    --data '{"id":"dFg8Us"}' \
+    --fail \
+    --header 'Content-type: application/json' \
+    --silent \
+    --request GET \
+      https://${DOMAIN}:${PORT}/cluster_exists? | jq .
+  ```
+  ```bash
+  {
+    "cluster_exists?": true
+  }
+  ```
+
+
+- - - -
+## GET cluster_hierarchy(id)
+Returns the chain of ids from the given `id` up to its topmost containing entity,
+ordered bottom-to-top as `[{type,id}, ...]` where `type` is `kata`, `group` or
+`cluster`. The first entry is the given id; the last entry's id is the topmost.
+Lets a caller resolve any id up to the practice it belongs to (eg a kata up to
+its cluster).
+- parameters
+  * **id:String**. A kata, group or cluster id.
+- returns
+  * the id chain. A solo kata returns just itself; a kata in a cluster returns
+    its kata, then group, then cluster.
+- example
+  ```bash
+  $ curl \
+    --data '{"id":"5rTJv5"}' \
+    --fail \
+    --header 'Content-type: application/json' \
+    --silent \
+    --request GET \
+      https://${DOMAIN}:${PORT}/cluster_hierarchy | jq .
+  ```
+  ```bash
+  {
+    "cluster_hierarchy": [
+      { "type": "kata",    "id": "5rTJv5" },
+      { "type": "group",   "id": "g1AbCd" },
+      { "type": "cluster", "id": "dFg8Us" }
+    ]
+  }
+  ```
+
+
+- - - -
 # Group API
 
 ## POST group_create(manifest)
@@ -109,10 +234,16 @@ Determines if a group with the given `id` exists.
   ```
 
 - - - -
-## POST group_join(id)
+## POST group_join(id, indexes)
 Creates a new kata in the group with the given `id` and returns the kata's id.
 - parameters 
   * **id:String**. The group id.
+  * **indexes:Array[int]** (optional). The candidate avatar indexes (from 0..63)
+    in preference order. The first index not already taken in the group is
+    allocated. Defaults to a shuffled 0..63. Pass a custom order to influence
+    which avatar a joiner gets. For example, in a cluster, list the avatars not
+    yet used elsewhere in the cluster first, so avatars stay distinct across the
+    cluster's groups.
 - returns 
   * the `id` of the created kata, or `null` if the group is already full.
 - example

--- a/source/server/app.rb
+++ b/source/server/app.rb
@@ -14,6 +14,8 @@ class App < AppBase
 
   post_json(:model, :cluster_create)
    get_json(:model, :cluster_manifest)
+   get_json(:model, :cluster_exists?)
+   get_json(:model, :cluster_hierarchy)
 
   # - - - - - - - - - - - - - - - - -
 

--- a/source/server/model.rb
+++ b/source/server/model.rb
@@ -14,23 +14,6 @@ class Model
     @externals = externals
   end
 
-  def group_create(manifest:)
-    version = from_manifest(manifest)
-    GROUPS[version].new(@externals).create(manifest)
-  end
-
-  def group_exists?(id:)
-    unless id?(id)
-      return false
-    end
-    dir_name = group_id_path(id)
-    disk.run(disk.dir_exists_command(dir_name))
-  end
-
-  def group_manifest(id:)
-    group(id).manifest(id)
-  end
-
   def cluster_create(manifest:)
     Cluster.new(@externals).create(manifest)
   end
@@ -51,7 +34,7 @@ class Model
   # bottom-to-top as [{type,id}, ...]; eg a kata in a cluster returns
   # [{kata},{group},{cluster}]. The top id is the last entry's id. Each step
   # appends its entry and advances id to its parent (group_id, then cluster_id).
-  def id_hierarchy(id:)
+  def cluster_hierarchy(id:)
     result = []
     if kata_exists?(id:id)
       result << { 'type' => 'kata', 'id' => id }
@@ -65,6 +48,25 @@ class Model
       result << { 'type' => 'cluster', 'id' => id }
     end
     result
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  def group_create(manifest:)
+    version = from_manifest(manifest)
+    GROUPS[version].new(@externals).create(manifest)
+  end
+
+  def group_exists?(id:)
+    unless id?(id)
+      return false
+    end
+    dir_name = group_id_path(id)
+    disk.run(disk.dir_exists_command(dir_name))
+  end
+
+  def group_manifest(id:)
+    group(id).manifest(id)
   end
 
   def group_join(id:, indexes:AVATAR_INDEXES.shuffle)
@@ -87,6 +89,8 @@ class Model
   def group_fork(id:, index:)
     kata(id).fork(Group_v2, id, index)
   end
+
+  # - - - - - - - - - - - - - - - - - - - -
 
   def kata_create(manifest:)
     version = from_manifest(manifest)
@@ -177,6 +181,8 @@ class Model
   def kata_option_set(id:, name:, value:)
     kata(id).option_set(id, name, value)
   end
+
+  # - - - - - - - - - - - - - - - - - - - -
 
   def diff_lines(id:, was_index:, now_index:)
     kata(id).diff_lines(id, was_index, now_index)

--- a/test/server/cluster_exists.rb
+++ b/test/server/cluster_exists.rb
@@ -1,0 +1,55 @@
+require_relative 'test_base'
+
+class ClusterExistsTest < TestBase
+
+  def two_ltf_cluster
+    cluster_create('exercise' => 'Tennis', 'ltfs' => [
+      manifest_Tennis_refactoring_Python_unitttest,
+      manifest_Tennis_refactoring_Ruby_minitest ])
+  end
+
+  test 'Ce7b01', %w(
+  | cluster_exists? is true for a created cluster
+  ) do
+    assert cluster_exists?(two_ltf_cluster)
+  end
+
+  test 'Ce7b02', %w(
+  | cluster_exists? is false for a well-formed id that does not exist
+  ) do
+    refute cluster_exists?('123AbZ')
+  end
+
+  test 'Ce7b03', %w(
+  | cluster_exists? is false for a group id or a kata id (neither is a cluster)
+  ) do
+    cluster_id = two_ltf_cluster
+    group_id = cluster_manifest(cluster_id)['children'].first['group_id']
+    kata_id  = group_join(group_id)
+    refute cluster_exists?(group_id), :group_id_is_not_a_cluster
+    refute cluster_exists?(kata_id),  :kata_id_is_not_a_cluster
+  end
+
+  test 'Ce7b04', %w(
+  | cluster_exists? is false for a malformed id
+  ) do
+    refute cluster_exists?(42), 'Integer'
+    refute cluster_exists?(nil), 'nil'
+    refute cluster_exists?([]), '[]'
+    refute cluster_exists?({}), '{}'
+    refute cluster_exists?(true), 'true'
+    refute cluster_exists?(''), 'length == 0'
+    refute cluster_exists?('12345'), 'length == 5'
+    refute cluster_exists?('12345i'), '!id?()'
+  end
+
+  test 'Ce7b05', %w(
+  | GET /cluster_exists? is callable and true for a created cluster
+  ) do
+    cluster_id = two_ltf_cluster
+    assert_json_get_200('cluster_exists?', { id: cluster_id }) do |exists|
+      assert exists, :cluster_exists
+    end
+  end
+
+end

--- a/test/server/cluster_hierarchy.rb
+++ b/test/server/cluster_hierarchy.rb
@@ -1,6 +1,6 @@
 require_relative 'test_base'
 
-class IdHierarchyTest < TestBase
+class ClusterHierarchyTest < TestBase
 
   def two_ltf_cluster
     cluster_create('exercise' => 'Tennis', 'ltfs' => [
@@ -10,7 +10,7 @@ class IdHierarchyTest < TestBase
 
   test 'Hy1a01', %w( | solo kata -> [kata] ) do
     in_kata do |kata_id|
-      assert_equal([{ 'type' => 'kata', 'id' => kata_id }], id_hierarchy(kata_id))
+      assert_equal([{ 'type' => 'kata', 'id' => kata_id }], cluster_hierarchy(kata_id))
     end
   end
 
@@ -18,7 +18,7 @@ class IdHierarchyTest < TestBase
     in_group do |group_id|
       kata_id = group_join(group_id)
       assert_equal([{ 'type' => 'kata',  'id' => kata_id },
-                    { 'type' => 'group', 'id' => group_id }], id_hierarchy(kata_id))
+                    { 'type' => 'group', 'id' => group_id }], cluster_hierarchy(kata_id))
     end
   end
 
@@ -28,12 +28,12 @@ class IdHierarchyTest < TestBase
     kata_id = group_join(group_id)
     assert_equal([{ 'type' => 'kata',    'id' => kata_id },
                   { 'type' => 'group',   'id' => group_id },
-                  { 'type' => 'cluster', 'id' => cluster_id }], id_hierarchy(kata_id))
+                  { 'type' => 'cluster', 'id' => cluster_id }], cluster_hierarchy(kata_id))
   end
 
   test 'Hy1a04', %w( | bare group -> [group] ) do
     in_group do |group_id|
-      assert_equal([{ 'type' => 'group', 'id' => group_id }], id_hierarchy(group_id))
+      assert_equal([{ 'type' => 'group', 'id' => group_id }], cluster_hierarchy(group_id))
     end
   end
 
@@ -41,12 +41,12 @@ class IdHierarchyTest < TestBase
     cluster_id = two_ltf_cluster
     group_id = cluster_manifest(cluster_id)['children'].first['group_id']
     assert_equal([{ 'type' => 'group',   'id' => group_id },
-                  { 'type' => 'cluster', 'id' => cluster_id }], id_hierarchy(group_id))
+                  { 'type' => 'cluster', 'id' => cluster_id }], cluster_hierarchy(group_id))
   end
 
   test 'Hy1a06', %w( | cluster -> [cluster] ) do
     cluster_id = two_ltf_cluster
-    assert_equal([{ 'type' => 'cluster', 'id' => cluster_id }], id_hierarchy(cluster_id))
+    assert_equal([{ 'type' => 'cluster', 'id' => cluster_id }], cluster_hierarchy(cluster_id))
   end
 
   versions_01_test 'Hy1a07', %w(
@@ -57,7 +57,7 @@ class IdHierarchyTest < TestBase
     kata_id  = katas[version]
     group_id = groups[version]
     assert_equal([{ 'type' => 'kata',  'id' => kata_id },
-                  { 'type' => 'group', 'id' => group_id }], id_hierarchy(kata_id))
+                  { 'type' => 'group', 'id' => group_id }], cluster_hierarchy(kata_id))
   end
 
   versions_01_test 'Hy1a08', %w(
@@ -65,14 +65,27 @@ class IdHierarchyTest < TestBase
   ) do
     groups = { 0 => 'FxWwrr', 1 => 'REf1t8' }
     group_id = groups[version]
-    assert_equal([{ 'type' => 'group', 'id' => group_id }], id_hierarchy(group_id))
+    assert_equal([{ 'type' => 'group', 'id' => group_id }], cluster_hierarchy(group_id))
   end
 
   test 'Hy1a09', %w(
   | a v1 solo kata (not in a group) -> [kata]
   ) do
     kata_id = 'H8NAvN'
-    assert_equal([{ 'type' => 'kata', 'id' => kata_id }], id_hierarchy(kata_id))
+    assert_equal([{ 'type' => 'kata', 'id' => kata_id }], cluster_hierarchy(kata_id))
+  end
+
+  test 'Hy1a10', %w(
+  | GET /cluster_hierarchy(id) returns the id chain for the given id
+  ) do
+    cluster_id = two_ltf_cluster
+    group_id = cluster_manifest(cluster_id)['children'].first['group_id']
+    kata_id = group_join(group_id)
+    assert_json_get_200('cluster_hierarchy', { id: kata_id }) do |chain|
+      assert_equal([{ 'type' => 'kata',    'id' => kata_id },
+                    { 'type' => 'group',   'id' => group_id },
+                    { 'type' => 'cluster', 'id' => cluster_id }], chain)
+    end
   end
 
 end

--- a/test/server/config/coverage_metrics_limits.rb
+++ b/test/server/config/coverage_metrics_limits.rb
@@ -2,12 +2,12 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 2952 ],
+    [ 'test.lines.total'    , '<=', 2987 ],
     [ 'test.lines.missed'   , '<=', 0    ],
     [ 'test.branches.total' , '<=', 4    ],
     [ 'test.branches.missed', '<=', 0    ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 1621 ],
+    [ 'code.lines.total'    , '<=', 1623 ],
     [ 'code.lines.missed'   , '<=', 0    ],
     [ 'code.branches.total' , '<=', 197  ],
     [ 'code.branches.missed', '<=', 0    ],

--- a/test/server/config/test_metrics_limits.rb
+++ b/test/server/config/test_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test_count',    '>=', 357 ],
+    [ 'test_count',    '>=', 363 ],
     [ 'total_time',    '<=',  50 ],
     [ nil ],
     [ 'failure_count', '<=', 0   ],

--- a/test/server/helpers/model.rb
+++ b/test/server/helpers/model.rb
@@ -32,12 +32,16 @@ module TestHelpersModel
     model.cluster_create(manifest:manifest)
   end
 
-  def id_hierarchy(id)
-    model.id_hierarchy(id:id)
+  def cluster_hierarchy(id)
+    model.cluster_hierarchy(id:id)
   end
 
   def cluster_manifest(id)
     model.cluster_manifest(id:id)
+  end
+
+  def cluster_exists?(id)
+    model.cluster_exists?(id:id)
   end
 
   AVATAR_INDEXES = (0..63).to_a


### PR DESCRIPTION
…rarchy

  creator and the dashboard are separate services that reach the saver over
  HTTP, so they need HTTP access to look up whether a 6-digit id is a cluster
  and to resolve any id up to the practice it belongs to. Both were Model-only
  methods; expose them as GET endpoints.

  Also rename id_hierarchy -> cluster_hierarchy. The name "id_hierarchy" was too
  generic; the method exists to resolve an id up to its containing cluster (via
  the kata.group_id -> group.cluster_id chain), so a cluster-oriented name makes
  its purpose clear.

  - app.rb: add get_json for cluster_exists? and cluster_hierarchy.
  - model.rb: rename id_hierarchy -> cluster_hierarchy.
  - test: rename id_hierarchy.rb -> cluster_hierarchy.rb (class + calls); add a dedicated cluster_exists.rb (true, well-formed-but-absent, a group/kata id is not a cluster, malformed ids) plus a GET endpoint test for each.
  - docs: list both in the README and api.md Cluster API sections.
  - bump the coverage/test metrics limits for the new code and tests.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>