### PR TITLE
Force ci run to pick up changes in secure-docker-build workflow

### DIFF
--- a/.github/workflows/force-ci-run
+++ b/.github/workflows/force-ci-run
@@ -1,2 +1,2 @@
 Edit this file for a quick way to force a CI run
-195
+196


### PR DESCRIPTION
The secure-docker-build now annotates the artifact with type=build and the intention is to use this annotation to improve the snyk scanning workflows determination of which flow among many in a environment snapshot is the build flow.