### PR TITLE
Ignore Snyk c-ares CVE-2026-33630 until Alpine v3.24 backports the fix

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,4 +2,12 @@
 # If this file contains only comments, then no vulnerabilities are ignored.
 # Referenced in the workflow's synk-test.
 
+ignore:
+  # CVE-2026-33630 | c-ares (via git -> libcurl) | Score 7.5 | No fix in Alpine v3.24 yet; c-ares DNS path unreached (saver's git use is local-only)
+  SNYK-ALPINE324-CARES-17896522:
+    - '*':
+        reason: No fix available in Alpine v3.24; see docs/vulns/readme.txt
+        expires: 2026-08-11T00:00:00.000Z
+        created: 2026-07-12T00:00:00.000Z
+
 patch: {}

--- a/docs/vulns/CVE-2026-33630.txt
+++ b/docs/vulns/CVE-2026-33630.txt
@@ -1,0 +1,25 @@
+CVE-2026-33630 | c-ares (Alpine 3.24) | CVSS 7.5 | Snyk severity: Low
+Snyk ID:   SNYK-ALPINE324-CARES-17896522
+Fixed in:  c-ares 1.34.8-r0 (NOT yet published to the Alpine v3.24 branch)
+Installed: c-ares 1.34.6-r0
+
+What: Remote denial-of-service in the c-ares asynchronous DNS resolver library
+(network attack vector, high availability impact, no confidentiality or
+integrity loss). NVD entry is still RESERVED; details are from Snyk / Red Hat.
+
+How it reaches the saver image: c-ares is not installed directly. The Dockerfile
+runs "apk add git"; git links libcurl (libcurl-8.21.0-r0) and libcurl links
+c-ares. git is the only installed package that pulls libcurl in.
+
+For saver: saver's only git use is local (source/server/model/kata_v2.rb):
+"git clone --quiet . <dir>" (clone from the local "."), "git remote remove origin"
+and "git update-ref". None perform DNS resolution, so the vulnerable c-ares path
+is never exercised. Saver does no other libcurl-based network name resolution.
+
+Why ignored: No fixed package (1.34.8-r0) is available in the Alpine v3.24 repo
+yet, so the image cannot be remediated by a rebuild or a base-image bump. git is
+still required at runtime, so the dependency cannot simply be dropped. The ignore
+is time-boxed so the vuln re-surfaces; once Alpine backports 1.34.8-r0 a routine
+rebuild removes it and this ignore entry should be deleted.
+
+Verdict: Not exercised by saver; no upstream fix available. Time-boxed ignore.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -1,0 +1,18 @@
+CVE Assessment: cyber-dojo saver image
+Generated: 2026-07-12
+
+Each vulnerability has its own file in this directory named after its CVE or Snyk ID.
+
+== Saver security posture ==
+
+Saver is an internal cyber-dojo microservice that stores kata data as git repos
+on disk. It is not directly internet-facing and runs no user-supplied code.
+Runs as UID 19663 (non-root, non-privileged; no shell, no home dir)
+git is used only for local repository operations (clone from ".", ref updates);
+saver performs no DNS resolution through git/libcurl/c-ares.
+
+== Summary table ==
+
+CVE / ID            Package                    Score  Exploitable?  Reason
+--------------------------------------------------------------------------------
+CVE-2026-33630      c-ares (via git->libcurl)  7.5    No   c-ares DNS path unreached; saver's git use is local-only. No fix in Alpine v3.24 yet.


### PR DESCRIPTION
  Snyk reports SNYK-ALPINE324-CARES-17896522 (CVE-2026-33630, a remote DoS
  in c-ares, fixed in 1.34.8-r0) against the saver image. The fixed package
  is not yet published to the Alpine v3.24 repo, so a rebuild or base-image
  bump cannot remediate it, and git is needed at runtime so the dependency
  (git -> libcurl -> c-ares) cannot be dropped.

  c-ares is not exercised by saver: its only git use is local (clone from
  ".", remote remove, update-ref), which does no DNS resolution. The ignore
  is time-boxed (expires 2026-08-11) so it re-surfaces; once Alpine backports
  1.34.8-r0 a routine rebuild removes it and this entry should be deleted.

  Document the assessment under docs/vulns/, following the pattern used by
  the runner repo.