### PR TITLE
End the solo false "mobbing?" dialog via per-event laptop_id

### DIFF
--- a/source/client/external/saver.rb
+++ b/source/client/external/saver.rb
@@ -72,32 +72,33 @@ module External
 
     # - - - - - - - - - - - - - - - - - -
 
-    def kata_file_create(id, index, files, filename)
-      @http.post(__method__, { id:id, index:index, files:files, filename:filename })
+    def kata_file_create(id, index, files, filename, laptop_id = nil)
+      @http.post(__method__, { id:id, index:index, files:files, filename:filename, laptop_id:laptop_id })
     end
 
-    def kata_file_delete(id, index, files, filename)
-      @http.post(__method__, { id:id, index:index, files:files, filename:filename })
+    def kata_file_delete(id, index, files, filename, laptop_id = nil)
+      @http.post(__method__, { id:id, index:index, files:files, filename:filename, laptop_id:laptop_id })
     end
 
-    def kata_file_rename(id, index, files, old_filename, new_filename)
-      @http.post(__method__, { 
-        id:id, 
-        index:index, 
-        files:files, 
-        old_filename:old_filename, 
-        new_filename:new_filename
+    def kata_file_rename(id, index, files, old_filename, new_filename, laptop_id = nil)
+      @http.post(__method__, {
+        id:id,
+        index:index,
+        files:files,
+        old_filename:old_filename,
+        new_filename:new_filename,
+        laptop_id:laptop_id
       })
     end
 
-    def kata_file_edit(id, index, files)
-      @http.post(__method__, { id:id, index:index, files:files })
+    def kata_file_edit(id, index, files, laptop_id = nil)
+      @http.post(__method__, { id:id, index:index, files:files, laptop_id:laptop_id })
     end
 
-    def kata_ran_tests(id, index, files, stdout, stderr, status, summary)
+    def kata_ran_tests(id, index, files, stdout, stderr, status, summary, laptop_id = nil)
       @http.post(__method__, {
         id:id, index:index, files:files,
-        stdout:stdout, stderr:stderr, status:status, summary:summary
+        stdout:stdout, stderr:stderr, status:status, summary:summary, laptop_id:laptop_id
       })
     end
 

--- a/source/server/external/git.rb
+++ b/source/server/external/git.rb
@@ -93,8 +93,8 @@ module External
     end
 
     # Builds the next commit on top of HEAD, in-process, on a single consistent
-    # base (so the caller's index check and the eventual update-ref CAS both key
-    # off the same base_oid). Replaces the files/ subtree with `files`
+    # base (so the caller's out-of-order detection and the eventual update-ref CAS
+    # both key off the same base_oid). Replaces the files/ subtree with `files`
     # (name => content), computes the files/ line-count delta vs HEAD's tree, and
     # yields (base_events, added, deleted) where base_events is HEAD's
     # events.json parsed. The block returns the remaining path => content writes

--- a/source/server/model.rb
+++ b/source/server/model.rb
@@ -139,42 +139,49 @@ class Model
 
   # - - - - - - - - - - - - - - - - - - - -
 
-  def kata_file_create(id:, index:, files:, filename:)
-    kata(id).file_create(id, index, files, filename)
+  # Each event-committing write accepts an optional laptop_id: the id of the
+  # browser (laptop) that made the write, minted as a cookie by web and sent on
+  # every event-write. It is accepted here so the strict-keyword dispatch does
+  # not reject it, but is not yet used or stored: web can start sending it before
+  # the saver acts on it. It powers mobbing detection (telling one laptop's
+  # events from another's) once the saver stamps events with it.
+
+  def kata_file_create(id:, index:, files:, filename:, laptop_id: nil)
+    kata(id).file_create(id, index, files, filename, laptop_id)
   end
 
-  def kata_file_delete(id:, index:, files:, filename:)
-    kata(id).file_delete(id, index, files, filename)
+  def kata_file_delete(id:, index:, files:, filename:, laptop_id: nil)
+    kata(id).file_delete(id, index, files, filename, laptop_id)
   end
 
-  def kata_file_rename(id:, index:, files:, old_filename:, new_filename:)
-    kata(id).file_rename(id, index, files, old_filename, new_filename)
+  def kata_file_rename(id:, index:, files:, old_filename:, new_filename:, laptop_id: nil)
+    kata(id).file_rename(id, index, files, old_filename, new_filename, laptop_id)
   end
 
-  def kata_file_edit(id:, index:, files:)
-    kata(id).file_edit(id, index, files)
+  def kata_file_edit(id:, index:, files:, laptop_id: nil)
+    kata(id).file_edit(id, index, files, laptop_id)
   end
 
   # - - - - - - - - - - - - - - - - - - - -
 
-  def kata_ran_tests(id:, index:, files:, stdout:, stderr:, status:, summary:)
-    kata(id).ran_tests(id, index, files, stdout, stderr, status, summary)
+  def kata_ran_tests(id:, index:, files:, stdout:, stderr:, status:, summary:, laptop_id: nil)
+    kata(id).ran_tests(id, index, files, stdout, stderr, status, summary, laptop_id)
   end
 
-  def kata_predicted_right(id:, index:, files:, stdout:, stderr:, status:, summary:)
-    kata(id).predicted_right(id, index, files, stdout, stderr, status, summary)
+  def kata_predicted_right(id:, index:, files:, stdout:, stderr:, status:, summary:, laptop_id: nil)
+    kata(id).predicted_right(id, index, files, stdout, stderr, status, summary, laptop_id)
   end
 
-  def kata_predicted_wrong(id:, index:, files:, stdout:, stderr:, status:, summary:)
-    kata(id).predicted_wrong(id, index, files, stdout, stderr, status, summary)
+  def kata_predicted_wrong(id:, index:, files:, stdout:, stderr:, status:, summary:, laptop_id: nil)
+    kata(id).predicted_wrong(id, index, files, stdout, stderr, status, summary, laptop_id)
   end
 
-  def kata_reverted(id:, index:, files:, stdout:, stderr:, status:, summary:)
-    kata(id).reverted(id, index, files, stdout, stderr, status, summary)
+  def kata_reverted(id:, index:, files:, stdout:, stderr:, status:, summary:, laptop_id: nil)
+    kata(id).reverted(id, index, files, stdout, stderr, status, summary, laptop_id)
   end
 
-  def kata_checked_out(id:, index:, files:, stdout:, stderr:, status:, summary:)
-    kata(id).checked_out(id, index, files, stdout, stderr, status, summary)
+  def kata_checked_out(id:, index:, files:, stdout:, stderr:, status:, summary:, laptop_id: nil)
+    kata(id).checked_out(id, index, files, stdout, stderr, status, summary, laptop_id)
   end
 
   # - - - - - - - - - - - - - - - - - - - -

--- a/source/server/model/kata_v0.rb
+++ b/source/server/model/kata_v0.rb
@@ -91,41 +91,41 @@ class Kata_v0
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def file_create(id, index, files, filename)
+  def file_create(id, index, files, filename, laptop_id)
     raise_not_implemented
   end
 
-  def file_delete(id, index, files, filename)
+  def file_delete(id, index, files, filename, laptop_id)
     raise_not_implemented
   end
 
-  def file_rename(id, index, files, old_filename, new_filename)
+  def file_rename(id, index, files, old_filename, new_filename, laptop_id)
     raise_not_implemented
   end
 
-  def file_edit(id, index, files)
+  def file_edit(id, index, files, laptop_id)
     raise_not_implemented
   end
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def ran_tests(id, index, files, stdout, stderr, status, summary)
+  def ran_tests(id, index, files, stdout, stderr, status, summary, laptop_id)
     raise_not_implemented
   end
 
-  def predicted_right(id, index, files, stdout, stderr, status, summary)
+  def predicted_right(id, index, files, stdout, stderr, status, summary, laptop_id)
     raise_not_implemented
   end
 
-  def predicted_wrong(id, index, files, stdout, stderr, status, summary)
+  def predicted_wrong(id, index, files, stdout, stderr, status, summary, laptop_id)
     raise_not_implemented
   end
 
-  def reverted(id, index, files, stdout, stderr, status, summary)
+  def reverted(id, index, files, stdout, stderr, status, summary, laptop_id)
     raise_not_implemented
   end
 
-  def checked_out(id, index, files, stdout, stderr, status, summary)
+  def checked_out(id, index, files, stdout, stderr, status, summary, laptop_id)
     raise_not_implemented
   end
 

--- a/source/server/model/kata_v1.rb
+++ b/source/server/model/kata_v1.rb
@@ -99,41 +99,41 @@ class Kata_v1
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def file_create(id, index, files, filename)
+  def file_create(id, index, files, filename, laptop_id)
     raise_not_implemented
   end
 
-  def file_delete(id, index, files, filename)
+  def file_delete(id, index, files, filename, laptop_id)
     raise_not_implemented
   end
 
-  def file_rename(id, index, files, old_filename, new_filename)
+  def file_rename(id, index, files, old_filename, new_filename, laptop_id)
     raise_not_implemented
   end
 
-  def file_edit(id, index, files)
+  def file_edit(id, index, files, laptop_id)
     raise_not_implemented
   end
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def ran_tests(id, index, files, stdout, stderr, status, summary)
+  def ran_tests(id, index, files, stdout, stderr, status, summary, laptop_id)
     raise_not_implemented
   end
 
-  def predicted_right(id, index, files, stdout, stderr, status, summary)
+  def predicted_right(id, index, files, stdout, stderr, status, summary, laptop_id)
     raise_not_implemented
   end
 
-  def predicted_wrong(id, index, files, stdout, stderr, status, summary)
+  def predicted_wrong(id, index, files, stdout, stderr, status, summary, laptop_id)
     raise_not_implemented
   end
 
-  def reverted(id, index, files, stdout, stderr, status, summary)
+  def reverted(id, index, files, stdout, stderr, status, summary, laptop_id)
     raise_not_implemented
   end
 
-  def checked_out(id, index, files, stdout, stderr, status, summary)
+  def checked_out(id, index, files, stdout, stderr, status, summary, laptop_id)
     raise_not_implemented
   end
 

--- a/source/server/model/kata_v2.rb
+++ b/source/server/model/kata_v2.rb
@@ -184,58 +184,58 @@ class Kata_v2
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def file_create(id, index, files, filename)
+  def file_create(id, index, files, filename, laptop_id)
     # Called just BEFORE filename is created in the browser.
     # So it is NOT yet present in files.keys
 
-    index = file_edit(id, index, files)
+    index = file_edit(id, index, files, laptop_id)
     files[filename] = { 'content' => '' }
     summary = { 'colour' => 'file_create', 'filename' => filename }
     # No quotes around the filename: the old save committed via a shell command
     # whose quoting stripped them, so historically the stored message had none.
     # The commit is now in-process (rugged), which uses the message literally.
     tag_message = "created file #{filename}"
-    result = git_commit_tag(id, index, files, summary, tag_message)
+    result = git_commit_tag(id, index, files, summary, tag_message, laptop_id)
     result['next_index']
   end
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def file_delete(id, index, files, filename)
+  def file_delete(id, index, files, filename, laptop_id)
     # Called just BEFORE filename is deleted in the browser.
     # So it IS present in files.
 
-    index = file_edit(id, index, files)
+    index = file_edit(id, index, files, laptop_id)
     files.delete(filename)
     summary = { 'colour' => 'file_delete', 'filename' => filename }
     # No quotes: see the note in file_create.
     tag_message = "deleted file #{filename}"
-    result = git_commit_tag(id, index, files, summary, tag_message)
+    result = git_commit_tag(id, index, files, summary, tag_message, laptop_id)
     result['next_index']
   end
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def file_rename(id, index, files, old_filename, new_filename)
+  def file_rename(id, index, files, old_filename, new_filename, laptop_id)
     # Called just BEFORE the rename in the browser.
     # So old_filename IS present in files.
     # And new_filename is NOT present in files.
 
-    index = file_edit(id, index, files)
+    index = file_edit(id, index, files, laptop_id)
     files[new_filename] = files.delete(old_filename)
-    summary = { 
-      'colour' => 'file_rename', 
+    summary = {
+      'colour' => 'file_rename',
       'old_filename' => old_filename,
-      'new_filename' => new_filename 
+      'new_filename' => new_filename
     }
     tag_message = "renamed file #{old_filename} to #{new_filename}"
-    result = git_commit_tag(id, index, files, summary, tag_message)
+    result = git_commit_tag(id, index, files, summary, tag_message, laptop_id)
     result['next_index']
   end
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def file_edit(id, index, files)
+  def file_edit(id, index, files, laptop_id)
     # Called in many places in the browser to indicate
     # that a file MAY have been edited (since the last save).
     # Creates a saver event if any file has been edited.
@@ -253,45 +253,45 @@ class Kata_v2
     summary = { 'colour' => 'file_edit', 'filename' => edited_filename }
     # No quotes: see the note in file_create.
     tag_message = "edited file #{edited_filename}"
-    result = git_commit_tag(id, index, files, summary, tag_message)
+    result = git_commit_tag(id, index, files, summary, tag_message, laptop_id)
     result['next_index']
   end
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def ran_tests(id, index, files, stdout, stderr, status, summary)
-    index = file_edit(id, index, files)
+  def ran_tests(id, index, files, stdout, stderr, status, summary, laptop_id)
+    index = file_edit(id, index, files, laptop_id)
     tag_message = "ran tests, no prediction, got #{summary['colour']}"
-    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message)
+    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message, laptop_id)
   end
 
-  def predicted_right(id, index, files, stdout, stderr, status, summary)
-    index = file_edit(id, index, files)
+  def predicted_right(id, index, files, stdout, stderr, status, summary, laptop_id)
+    index = file_edit(id, index, files, laptop_id)
     tag_message = "ran tests, predicted #{summary['predicted']}, got #{summary['colour']}"
-    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message)
+    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message, laptop_id)
   end
 
-  def predicted_wrong(id, index, files, stdout, stderr, status, summary)
-    index = file_edit(id, index, files)
+  def predicted_wrong(id, index, files, stdout, stderr, status, summary, laptop_id)
+    index = file_edit(id, index, files, laptop_id)
     tag_message = "ran tests, predicted #{summary['predicted']}, got #{summary['colour']}"
-    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message)
+    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message, laptop_id)
   end
 
-  def reverted(id, index, files, stdout, stderr, status, summary)
+  def reverted(id, index, files, stdout, stderr, status, summary, laptop_id)
     revert = summary['revert']
     info = json_plain({ 'id' => revert[0], 'index' => revert[1] })
     # info.inspect added escaping that the old shell-quoting path stripped back
     # out, so the historical message was the plain JSON. The in-process (rugged)
     # commit uses the message literally, so embed the plain JSON directly.
     tag_message = "reverted to #{info}"
-    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message)
+    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message, laptop_id)
   end
 
-  def checked_out(id, index, files, stdout, stderr, status, summary)
+  def checked_out(id, index, files, stdout, stderr, status, summary, laptop_id)
     info = json_plain(summary['checkout'])
     # Plain JSON, not info.inspect: see the note in reverted.
     tag_message = "checked out #{info}"
-    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message)
+    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message, laptop_id)
   end
 
   # - - - - - - - - - - - - - - - - - - - - - -
@@ -393,18 +393,18 @@ class Kata_v2
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def git_commit_tag(id, index, files, summary, tag_message)
+  def git_commit_tag(id, index, files, summary, tag_message, laptop_id)
     stdout = { 'content' => '', 'truncated' => false }
     stderr = { 'content' => '', 'truncated' => false }
     status = 0
-    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message)
+    git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message, laptop_id)
   end
-  
-  def git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message)
-    all_events = commit_event(id, index, files, stdout, stderr, status, summary, tag_message)
+
+  def git_commit_tag_sss(id, index, files, stdout, stderr, status, summary, tag_message, laptop_id)
+    all_events = commit_event(id, index, files, stdout, stderr, status, summary, tag_message, laptop_id)
 
     {
-      'next_index' => index + 1,
+      'next_index' => all_events.last['index'] + 1,
       'major_index' => major_index(all_events, index),
       'minor_index' => 0
     }
@@ -412,7 +412,7 @@ class Kata_v2
 
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  def commit_event(id, index, files, stdout, stderr, status, summary, tag_message)
+  def commit_event(id, index, files, stdout, stderr, status, summary, tag_message, laptop_id)
     # Builds the event commit in-process (libgit2/rugged) on a single base,
     # advances main onto it with an update-ref compare-and-swap, then tags it.
     # No worktree, no working-tree checkout (the working tree stays stale; reads
@@ -420,30 +420,64 @@ class Kata_v2
     #
     # Out-of-sync detection has two layers, each catching a different scenario.
     #
-    # 1. Sequential stale index (inside the commit_on_main block):
-    #    The client sends an index behind the current last_index, with no
-    #    concurrent request. The unless check raises before any commit is
-    #    created, so no corrupt data (e.g. two events with the same index) is
-    #    ever written.
+    # 1. Per-write placement + detection (inside the commit_on_main block, before
+    #    any commit is created, so no corrupt data is ever written):
+    #    - no laptop_id: today's check - the client index must be exactly the next
+    #      position (last_index + 1), else "Out of order event".
+    #    - laptop_id present: the saver places the event at head + 1; it rejects an
+    #      index ahead of that, and rejects an index behind head when the events
+    #      the browser missed (index .. head) include a different laptop's write
+    #      (genuine mobbing). A behind index whose missed events are all this same
+    #      laptop's own writes is accepted (self-lag).
     #
-    # 2. Concurrent write (rescue block):
-    #    Two saves for the same kata arrive together. Both build their commit on
-    #    the same base_oid (the shared HEAD) and both pass the index check.
-    #    Whichever reaches the update-ref compare-and-swap second fails, because
-    #    main has already moved off base_oid. The rescue re-reads events.json
-    #    from HEAD: if last_index >= index a concurrent write succeeded first, so
-    #    "Out of order event" is raised. Any other failure is re-raised as-is.
+    # 2. Concurrent write (the method-level rescue below):
+    #    Two saves for the same kata arrive together, build on the same base_oid,
+    #    and both pass layer 1. Whichever reaches the update-ref compare-and-swap
+    #    second fails (main has moved off base_oid). The rescue re-reads the tip via
+    #    git: if last_index >= index a concurrent write won, so "Out of order event"
+    #    is raised; any other failure is re-raised as-is.
     all_events = nil
+    place_at = nil
     result = git.commit_on_main(repo_dir(id), "#{index} #{tag_message}", content_of(files)) do |base_events, added, deleted|
-      unless index == base_events.last['index'] + 1
-        raise "Out of order event for #{id}"
+      if laptop_id.nil?
+        # No laptop_id (legacy events, or a client not yet sending one): today's
+        # behavior unchanged - the client index must be exactly the next position.
+        unless index == base_events.last['index'] + 1
+          raise "Out of order event for #{id}"
+        end
+        place_at = index
+      else
+        # laptop_id present: placement is saver-authoritative (the saver, not web,
+        # decides it: head + 1). An index ahead of head + 1 claims a position that
+        # does not exist and is rejected. An index behind head means the browser
+        # missed commits; accept it only when every event it has not yet seen
+        # (index .. head) was written by this same laptop (its own lost-response
+        # writes), otherwise a different laptop got in and it is rejected as
+        # mobbing.
+        head = base_events.last['index']
+        place_at = head + 1
+        unless index == place_at
+          if index > place_at
+            raise "Out of order event for #{id}"
+          end
+          intervening = base_events.select { |event| event['index'] >= index }
+          unless intervening.all? { |event| event['laptop_id'] == laptop_id }
+            raise "Out of order event for #{id}"
+          end
+        end
       end
-      all_events = base_events + [summary.merge!({
-        'index' => index,
+      new_event = summary.merge!({
+        'index' => place_at,
         'time' => time.now,
         'diff_added_count' => added,
         'diff_deleted_count' => deleted
-      })]
+      })
+      # Only stamp the writing laptop when a well-formed id was supplied. A nil,
+      # absent, or malformed laptop_id stores no laptop_id key at all, so such an
+      # event is indistinguishable from a pre-laptop_id event and its writer is
+      # treated as unknown. Only the genuine minted format is trusted.
+      new_event['laptop_id'] = laptop_id if valid_laptop_id?(laptop_id)
+      all_events = base_events + [new_event]
       {
         events_filename => json_pretty(all_events),
         'stdout' => stdout['content'],
@@ -469,7 +503,7 @@ class Kata_v2
     # concurrency mechanism (loser detection), so it cannot be dropped. See
     # docs/in-process-git.md.
     shell.assert_cd_exec(repo_dir(id), "git update-ref refs/heads/main #{result[:new_oid]} #{result[:base_oid]}")
-    git.create_tag(repo_dir(id), index, result[:new_oid])
+    git.create_tag(repo_dir(id), place_at, result[:new_oid])
 
     all_events
   rescue
@@ -483,6 +517,16 @@ class Kata_v2
       raise "Out of order event for #{id}"
     end
     raise
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - -
+
+  # A laptop_id is the 64-char lowercase-hex cookie minted by web
+  # (SecureRandom.hex(32)). Anything else (nil, wrong length, non-hex,
+  # uppercase) is not trusted and is not stored, so the event reads as having
+  # an unknown writer.
+  def valid_laptop_id?(laptop_id)
+    laptop_id.is_a?(String) && laptop_id.match?(/\A[0-9a-f]{64}\z/)
   end
 
   # - - - - - - - - - - - - - - - - - - - - - -

--- a/test/client/config/coverage_metrics_limits.rb
+++ b/test/client/config/coverage_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 1012 ],
+    [ 'test.lines.total'    , '<=', 1014 ],
     [ 'test.lines.missed'   , '<=',    0 ],
     [ 'test.branches.total' , '<=',    4 ],
     [ 'test.branches.missed', '<=',    0 ],

--- a/test/client/config/coverage_metrics_limits.rb
+++ b/test/client/config/coverage_metrics_limits.rb
@@ -2,14 +2,14 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 985 ],
-    [ 'test.lines.missed'   , '<=', 0   ],
-    [ 'test.branches.total' , '<=', 4   ],
-    [ 'test.branches.missed', '<=', 0   ],
+    [ 'test.lines.total'    , '<=', 1012 ],
+    [ 'test.lines.missed'   , '<=',    0 ],
+    [ 'test.branches.total' , '<=',    4 ],
+    [ 'test.branches.missed', '<=',    0 ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 142 ],
-    [ 'code.lines.missed'   , '<=', 0   ],
-    [ 'code.branches.total' , '<=', 2   ],
-    [ 'code.branches.missed', '<=', 0   ],
+    [ 'code.lines.total'    , '<=',  142 ],
+    [ 'code.lines.missed'   , '<=',    0 ],
+    [ 'code.branches.total' , '<=',    2 ],
+    [ 'code.branches.missed', '<=',    0 ],
   ]
 end

--- a/test/client/config/test_metrics_limits.rb
+++ b/test/client/config/test_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test_count',    '>=', 152 ],
+    [ 'test_count',    '>=', 155 ],
     [ 'total_time',    '<=', 30  ],
     [ nil ],
     [ 'failure_count', '<=', 0   ],

--- a/test/client/kata_concurrent_saves_test.rb
+++ b/test/client/kata_concurrent_saves_test.rb
@@ -22,7 +22,7 @@ class KataConcurrentSavesTest < TestBase
 
       n.times.map do
         Thread.new do
-          saver.kata_ran_tests(id, 1, files, stdout, stderr, status, summary)
+          saver.kata_ran_tests(id, 1, files, stdout, stderr, status, summary, laptop_id)
         rescue => error
           mu.synchronize { errors << error.message }
         end

--- a/test/client/kata_concurrent_saves_test.rb
+++ b/test/client/kata_concurrent_saves_test.rb
@@ -1,13 +1,17 @@
 require_relative 'test_base'
+require 'securerandom'
 
 class KataConcurrentSavesTest < TestBase
 
   version_test 2, 'DccG02', %w(
-  | N concurrent kata_ran_tests calls to the same kata-id all use index=1.
-  | Exactly one succeeds. The remaining N-1 all get 'Out of order event':
-  | either from the index check (sequential case) or from the failed
-  | update-ref compare-and-swap (concurrent case). Even sequential execution
-  | cannot produce more than one success since all threads hardcode index=1.
+  | N concurrent kata_ran_tests calls to the same kata-id, each from a DIFFERENT
+  | laptop_id, all use index=1 (genuine mobbing: N laptops racing the same
+  | next-event slot). Exactly one succeeds. The remaining N-1 all get
+  | 'Out of order event': either from losing the update-ref compare-and-swap
+  | (concurrent case) or from the mobbing check rejecting a behind index whose
+  | intervening event was written by a different laptop (sequential case).
+  | Distinct laptop_ids are essential: with a shared laptop_id a behind write is
+  | accepted as self-lag, so more than one call could succeed.
   ) do
     n = 10
     in_kata do |id|
@@ -17,12 +21,13 @@ class KataConcurrentSavesTest < TestBase
       status  = 0
       summary = { 'colour' => 'red', 'predicted' => 'none' }
 
+      laptop_ids = n.times.map { SecureRandom.hex(32) }
       errors = []
       mu = Mutex.new
 
-      n.times.map do
+      n.times.map do |i|
         Thread.new do
-          saver.kata_ran_tests(id, 1, files, stdout, stderr, status, summary, laptop_id)
+          saver.kata_ran_tests(id, 1, files, stdout, stderr, status, summary, laptop_ids[i])
         rescue => error
           mu.synchronize { errors << error.message }
         end

--- a/test/client/kata_diff_v2.rb
+++ b/test/client/kata_diff_v2.rb
@@ -10,7 +10,7 @@ class KataDiffV2Test < TestBase
     in_tennis_kata do |id, files|
       original_content = files['cyber-dojo.sh']['content']
       files['cyber-dojo.sh']['content'] = original_content + "Hello\nWorld\n"
-      kata_file_edit(id, 1, files)
+      kata_file_edit(id, 1, files, laptop_id)
       assert_diff(id, 0, 1, {
         'type'         => 'changed',
         'old_filename' => 'cyber-dojo.sh',
@@ -336,8 +336,8 @@ class KataDiffV2Test < TestBase
     was['cyber-dojo.sh'] = files0['cyber-dojo.sh'] + "\n# was"
     now = files0.merge(@now_files)
     now['cyber-dojo.sh'] = files0['cyber-dojo.sh'] + "\n# now"
-    kata_file_edit(id, 1, plain(was))
-    kata_file_edit(id, 2, plain(now))
+    kata_file_edit(id, 1, plain(was), laptop_id)
+    kata_file_edit(id, 2, plain(now), laptop_id)
     [id, 1, 2]
   end
 

--- a/test/client/kata_event_test.rb
+++ b/test/client/kata_event_test.rb
@@ -33,7 +33,7 @@ class KataEventTest < TestBase
 
       files = event['files']
       index = 1
-      kata_file_create(id, index, files, 'wibble.txt')
+      kata_file_create(id, index, files, 'wibble.txt', laptop_id)
       kata_event(id, index)
 
       bad_index = 2
@@ -52,7 +52,7 @@ class KataEventTest < TestBase
 
       files = event['files']
       index = 1
-      kata_file_create(id, index, files, 'wibble.txt')
+      kata_file_create(id, index, files, 'wibble.txt', laptop_id)
       index = -2
       kata_event(id, index)
 

--- a/test/client/kata_file_create.rb
+++ b/test/client/kata_file_create.rb
@@ -12,7 +12,7 @@ class KataFileCreateTest < TestBase
       files = kata_event(id, 0)['files']
       refute files.keys.include?('wibble.txt') 
 
-      next_index = kata_file_create(id, index=1, files, 'wibble.txt')
+      next_index = kata_file_create(id, index=1, files, 'wibble.txt', laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index
@@ -41,7 +41,7 @@ class KataFileCreateTest < TestBase
       edited_content = files['readme.txt']['content'] + 'Hello world'
       files['readme.txt']['content'] = edited_content
 
-      next_index = kata_file_create(id, index=1, files, 'wibble.txt')
+      next_index = kata_file_create(id, index=1, files, 'wibble.txt', laptop_id)
 
       events = kata_events(id)
       assert_equal 3, next_index

--- a/test/client/kata_file_delete.rb
+++ b/test/client/kata_file_delete.rb
@@ -11,7 +11,7 @@ class KataFileDeleteTest < TestBase
       files = kata_event(id, 0)['files']
       assert files.keys.include?('readme.txt') 
 
-      next_index = kata_file_delete(id, index=1, files, 'readme.txt')
+      next_index = kata_file_delete(id, index=1, files, 'readme.txt', laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index
@@ -42,7 +42,7 @@ class KataFileDeleteTest < TestBase
       edited_content = files['readme.txt']['content'] + 'Hello world'
       files['readme.txt']['content'] = edited_content
       
-      next_index = kata_file_delete(id, index=1, files, 'tennis.py')
+      next_index = kata_file_delete(id, index=1, files, 'tennis.py', laptop_id)
 
       events = kata_events(id)
       assert_equal 3, next_index
@@ -79,7 +79,7 @@ class KataFileDeleteTest < TestBase
       edited_content = files['readme.txt']['content'] + 'Hello world'
       files['readme.txt']['content'] = edited_content
       
-      next_index = kata_file_delete(id, index=1, files, 'readme.txt')
+      next_index = kata_file_delete(id, index=1, files, 'readme.txt', laptop_id)
 
       events = kata_events(id)
       assert_equal 3, next_index

--- a/test/client/kata_file_edit.rb
+++ b/test/client/kata_file_edit.rb
@@ -9,7 +9,7 @@ class KataFileEditTest < TestBase
   ) do
     in_kata do |id|
       files = kata_event(id, 0)['files']
-      next_index = kata_file_edit(id, index=1, files)
+      next_index = kata_file_edit(id, index=1, files, laptop_id)
 
       events = kata_events(id)
       assert_equal 1, next_index
@@ -32,7 +32,7 @@ class KataFileEditTest < TestBase
       edited_content = files['readme.txt']['content'] + 'Hello world'
       files['readme.txt']['content'] = edited_content
 
-      next_index = kata_file_edit(id, index=1, files)
+      next_index = kata_file_edit(id, index=1, files, laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index

--- a/test/client/kata_file_rename.rb
+++ b/test/client/kata_file_rename.rb
@@ -11,7 +11,7 @@ class KataFileRenameTest < TestBase
       files = kata_event(id, 0)['files']
       content = files['readme.txt']['content']
       
-      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md')
+      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md', laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index
@@ -44,7 +44,7 @@ class KataFileRenameTest < TestBase
       renamed_content = files['readme.txt']['content']
       files['tennis.py']['content'] = edited_content
       
-      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md')
+      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md', laptop_id)
 
       events = kata_events(id)
       assert_equal 3, next_index
@@ -82,7 +82,7 @@ class KataFileRenameTest < TestBase
       edited_content = files['readme.txt']['content'] + '# some comment'
       files['readme.txt']['content'] = edited_content
       
-      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md')
+      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md', laptop_id)
 
       events = kata_events(id)
       assert_equal 3, next_index

--- a/test/client/kata_laptop_id_test.rb
+++ b/test/client/kata_laptop_id_test.rb
@@ -1,0 +1,47 @@
+require_relative 'test_base'
+
+class KataLaptopIdTest < TestBase
+
+  version_test 2, 'La7C01', %w(
+  | a kata_file_create passing a well-formed laptop_id stores it on the
+  | committed event, read back through the client
+  ) do
+    in_kata do |id|
+      files = kata_event(id, 0)['files']
+      saver.kata_file_create(id, 1, files, 'wibble.txt', laptop_id)
+      assert_equal laptop_id, kata_event(id, 1)['laptop_id']
+    end
+  end
+
+  version_test 2, 'La7C02', %w(
+  | a kata_file_create with no laptop_id (the transitional default) still
+  | succeeds and stores no laptop_id key on the event
+  ) do
+    in_kata do |id|
+      files = kata_event(id, 0)['files']
+      next_index = saver.kata_file_create(id, 1, files, 'wibble.txt')
+      assert_equal 2, next_index
+      refute kata_event(id, 1).key?('laptop_id'), kata_event(id, 1).to_json
+    end
+  end
+
+  version_test 2, 'La7C03', %w(
+  | a stale-index write from a different laptop_id is rejected by the saver as
+  | out-of-order (genuine mobbing), surfaced through the client as a ServiceError.
+  ) do
+    in_kata do |id|
+      files = kata_event(id, 0)['files']
+      stdout = { 'content' => 'o', 'truncated' => false }
+      stderr = { 'content' => 'e', 'truncated' => false }
+      summary = { 'colour' => 'red', 'predicted' => 'none' }
+
+      saver.kata_ran_tests(id, 1, files, stdout, stderr, 0, summary, laptop_id)
+
+      error = assert_raises(HttpJsonHash::ServiceError) {
+        saver.kata_ran_tests(id, 1, files, stdout, stderr, 0, summary, another_laptop_id)
+      }
+      assert_equal "Out of order event for #{id}", error.message
+    end
+  end
+
+end

--- a/test/client/test_base.rb
+++ b/test/client/test_base.rb
@@ -76,20 +76,33 @@ class TestBase < Id58TestBase
 
   # - - - - - - - - - - - - - - - - - -
 
-  def kata_file_create(id, index, files, filename)
-    saver.kata_file_create(id, index, files, filename)
+  # An arbitrary well-formed laptop_id (SecureRandom.hex(32) format), passed
+  # explicitly by tests on every event-write as a real client now does. Its
+  # specific value is not significant.
+  def laptop_id
+    'd4f9a0c71e2b85630af1c9e4b7028d5f6a3c1e8092b4d7f60a5e3c19b8d24f70'
   end
 
-  def kata_file_delete(id, index, files, filename)
-    saver.kata_file_delete(id, index, files, filename)
+  # A second well-formed laptop_id, distinct from laptop_id, for tests that need
+  # two different laptops (genuine mobbing).
+  def another_laptop_id
+    'ca990e850c196480e16b8f04a611297e12ea64c93766055643e0e60f8f8d51e0'
   end
 
-  def kata_file_rename(id, index, files, old_filename, new_filename)
-    saver.kata_file_rename(id, index, files, old_filename, new_filename)
+  def kata_file_create(id, index, files, filename, laptop_id)
+    saver.kata_file_create(id, index, files, filename, laptop_id)
   end
 
-  def kata_file_edit(id, index, files)
-    saver.kata_file_edit(id, index, files)
+  def kata_file_delete(id, index, files, filename, laptop_id)
+    saver.kata_file_delete(id, index, files, filename, laptop_id)
+  end
+
+  def kata_file_rename(id, index, files, old_filename, new_filename, laptop_id)
+    saver.kata_file_rename(id, index, files, old_filename, new_filename, laptop_id)
+  end
+
+  def kata_file_edit(id, index, files, laptop_id)
+    saver.kata_file_edit(id, index, files, laptop_id)
   end
 
   # - - - - - - - - - - - - - - - - - -

--- a/test/server/config/coverage_metrics_limits.rb
+++ b/test/server/config/coverage_metrics_limits.rb
@@ -2,14 +2,14 @@
 def metrics
   [
     [ nil ],
-    [ 'test.lines.total'    , '<=', 3011 ],
+    [ 'test.lines.total'    , '<=', 3134 ],
     [ 'test.lines.missed'   , '<=', 0    ],
     [ 'test.branches.total' , '<=', 4    ],
     [ 'test.branches.missed', '<=', 0    ],
     [ nil ],
-    [ 'code.lines.total'    , '<=', 1631 ],
+    [ 'code.lines.total'    , '<=', 1646 ],
     [ 'code.lines.missed'   , '<=', 0    ],
-    [ 'code.branches.total' , '<=', 205  ],
+    [ 'code.branches.total' , '<=', 215  ],
     [ 'code.branches.missed', '<=', 0    ],
   ]
 end

--- a/test/server/config/test_metrics_limits.rb
+++ b/test/server/config/test_metrics_limits.rb
@@ -2,7 +2,7 @@
 def metrics
   [
     [ nil ],
-    [ 'test_count',    '>=', 373 ],
+    [ 'test_count',    '>=', 384 ],
     [ 'total_time',    '<=',  50 ],
     [ nil ],
     [ 'failure_count', '<=', 0   ],

--- a/test/server/differ.rb
+++ b/test/server/differ.rb
@@ -339,13 +339,13 @@ class DifferTest < TestBase
       @was_files[filename] = data['content']
     end
     was_index = event['index'] + 1
-    result = kata_ran_tests(id, was_index, @was_files)
+    result = kata_ran_tests(id, was_index, @was_files, laptop_id)
     now_index = result['next_index']
 
     event['files'].each do |filename, data|
       @now_files[filename] = data['content']
     end
-    _result = kata_ran_tests(id, now_index, @now_files)
+    _result = kata_ran_tests(id, now_index, @now_files, laptop_id)
 
     [id, was_index, now_index]
   end
@@ -361,7 +361,7 @@ class DifferTest < TestBase
 
   # - - - - - - - - - - - - -
 
-  def kata_ran_tests(id, index, files)
+  def kata_ran_tests(id, index, files, laptop_id)
     model.kata_ran_tests(
       id: id,
       index: index,

--- a/test/server/group_fork.rb
+++ b/test/server/group_fork.rb
@@ -48,7 +48,7 @@ class GroupForkTest < TestBase
         "duration" => 1.46448,
         "predicted" => "none",
       }
-      kata_ran_tests(kid, index=1, files, stdout, stderr, status, red_summary)
+      kata_ran_tests(kid, index=1, files, stdout, stderr, status, red_summary, laptop_id)
 
       fid = group_fork(kid, index)
 

--- a/test/server/helpers/model.rb
+++ b/test/server/helpers/model.rb
@@ -74,69 +74,69 @@ module TestHelpersModel
 
   # - - - - - - - - - - - - - - - - - - - - -
 
-  def kata_file_create(id, index, files, filename)
+  def kata_file_create(id, index, files, filename, laptop_id)
     model.kata_file_create(
-      id:id, index:index, files:files, filename:filename
+      id:id, index:index, files:files, filename:filename, laptop_id:laptop_id
     )
   end
 
-  def kata_file_delete(id, index, files, filename)
+  def kata_file_delete(id, index, files, filename, laptop_id)
     model.kata_file_delete(
-      id:id, index:index, files:files, filename:filename
+      id:id, index:index, files:files, filename:filename, laptop_id:laptop_id
     )
   end
 
-  def kata_file_rename(id, index, files, old_filename, new_filename)
+  def kata_file_rename(id, index, files, old_filename, new_filename, laptop_id)
     model.kata_file_rename(
-      id:id, index:index, files:files, old_filename:old_filename, new_filename:new_filename
+      id:id, index:index, files:files, old_filename:old_filename, new_filename:new_filename, laptop_id:laptop_id
     )
   end
 
-  def kata_file_edit(id, index, files)
+  def kata_file_edit(id, index, files, laptop_id)
     model.kata_file_edit(
-      id:id, index:index, files:files
+      id:id, index:index, files:files, laptop_id:laptop_id
     )
   end
 
   # - - - - - - - - - - - - - - - - - - - - -
 
-  def kata_ran_tests(id, index, files, stdout, stderr, status, summary)
+  def kata_ran_tests(id, index, files, stdout, stderr, status, summary, laptop_id)
     model.kata_ran_tests(
       id:id, index:index,
       files:files, stdout:stdout, stderr:stderr, status:status,
-      summary:summary
+      summary:summary, laptop_id:laptop_id
     )
   end
 
-  def kata_predicted_right(id, index, files, stdout, stderr, status, summary)
+  def kata_predicted_right(id, index, files, stdout, stderr, status, summary, laptop_id)
     model.kata_predicted_right(
       id:id, index:index,
       files:files, stdout:stdout, stderr:stderr, status:status,
-      summary:summary
+      summary:summary, laptop_id:laptop_id
     )
   end
 
-  def kata_predicted_wrong(id, index, files, stdout, stderr, status, summary)
+  def kata_predicted_wrong(id, index, files, stdout, stderr, status, summary, laptop_id)
     model.kata_predicted_wrong(
       id:id, index:index,
       files:files, stdout:stdout, stderr:stderr, status:status,
-      summary:summary
+      summary:summary, laptop_id:laptop_id
     )
   end
 
-  def kata_reverted(id, index, files, stdout, stderr, status, summary)
+  def kata_reverted(id, index, files, stdout, stderr, status, summary, laptop_id)
     model.kata_reverted(
       id:id, index:index,
       files:files, stdout:stdout, stderr:stderr, status:status,
-      summary:summary
+      summary:summary, laptop_id:laptop_id
     )
   end
 
-  def kata_checked_out(id, index, files, stdout, stderr, status, summary)
+  def kata_checked_out(id, index, files, stdout, stderr, status, summary, laptop_id)
     model.kata_checked_out(
       id:id, index:index,
       files:files, stdout:stdout, stderr:stderr, status:status,
-      summary:summary
+      summary:summary, laptop_id:laptop_id
     )
   end
 

--- a/test/server/kata_checked_out.rb
+++ b/test/server/kata_checked_out.rb
@@ -14,7 +14,7 @@ class KataCheckedOutTest < TestBase
       stdout = data['stdout']
       stderr = data['stderr']
       status = data['status']
-      kata_ran_tests(id1, index=1, files, stdout, stderr, status, red_summary)
+      kata_ran_tests(id1, index=1, files, stdout, stderr, status, red_summary, laptop_id)
 
       id2 = group_join(gid)
       checkout = { 
@@ -26,7 +26,7 @@ class KataCheckedOutTest < TestBase
         'colour' => 'red', 
         'checkout' => checkout 
       }
-      kata_checked_out(id2, index=1, files, stdout, stderr, status, checkout_out_summary)
+      kata_checked_out(id2, index=1, files, stdout, stderr, status, checkout_out_summary, laptop_id)
 
       expected = JSON.generate(checkout)
       assert_tag_commit_message(id2, 1, "1 checked out #{expected}")
@@ -49,7 +49,7 @@ class KataCheckedOutTest < TestBase
       stderr = data['stderr']
       status = data['status']
 
-      result = kata_ran_tests(id1, next_index=1, files, stdout, stderr, status, red_summary)
+      result = kata_ran_tests(id1, next_index=1, files, stdout, stderr, status, red_summary, laptop_id)
       assert_equal 2, result['next_index']
 
       id2 = group_join(gid)
@@ -63,7 +63,7 @@ class KataCheckedOutTest < TestBase
         'checkout' => checkout 
       }
 
-      result = kata_checked_out(id2, index=1, files, stdout, stderr, status, checkout_out_summary)
+      result = kata_checked_out(id2, index=1, files, stdout, stderr, status, checkout_out_summary, laptop_id)
       next_index = result['next_index']
 
       actual = kata_event(id2, next_index - 1)
@@ -96,7 +96,7 @@ class KataCheckedOutTest < TestBase
       'checkout' => { 'id' => id, 'index' => 0, 'avatarIndex' => 0 }
     }
     assert_raises(NoLongerImplementedError) do
-      kata_checked_out(id, 1, files, data['stdout'], data['stderr'], data['status'], checkout_summary)
+      kata_checked_out(id, 1, files, data['stdout'], data['stderr'], data['status'], checkout_summary, laptop_id)
     end
   end
 

--- a/test/server/kata_diff.rb
+++ b/test/server/kata_diff.rb
@@ -284,12 +284,12 @@ class KataDiffTest < TestBase
       @was_files[filename] = data['content']
     end
     was_index = event['index'] + 1
-    result = kata_ran_tests(id, was_index, @was_files)
+    result = kata_ran_tests(id, was_index, @was_files, laptop_id)
     now_index = result['next_index']
     event['files'].each do |filename, data|
       @now_files[filename] = data['content']
     end
-    kata_ran_tests(id, now_index, @now_files)
+    kata_ran_tests(id, now_index, @now_files, laptop_id)
     [id, was_index, now_index]
   end
 
@@ -300,7 +300,7 @@ class KataDiffTest < TestBase
     manifest
   end
 
-  def kata_ran_tests(id, index, files)
+  def kata_ran_tests(id, index, files, laptop_id)
     model.kata_ran_tests(
       id: id,
       index: index,

--- a/test/server/kata_diff_added_deleted.rb
+++ b/test/server/kata_diff_added_deleted.rb
@@ -19,7 +19,7 @@ class KataDiffAddedDeletedTest < TestBase
       edited_content = files['readme.txt']['content'] + "\n" + added_lines.join("\n")
 
       files['readme.txt']['content'] = edited_content
-      next_index = kata_file_edit(id, index=1, files)
+      next_index = kata_file_edit(id, index=1, files, laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index
@@ -43,7 +43,7 @@ class KataDiffAddedDeletedTest < TestBase
       assert deleted_lines.size > 0
 
       files['readme.txt']['content'] = ''
-      next_index = kata_file_edit(id, index=1, files)
+      next_index = kata_file_edit(id, index=1, files, laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index
@@ -62,7 +62,7 @@ class KataDiffAddedDeletedTest < TestBase
   | shows diff_added_lines=0, diff_deleted_lines=0
   ) do
     in_tennis_kata do |id, files|
-      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme2.txt')
+      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme2.txt', laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index
@@ -81,7 +81,7 @@ class KataDiffAddedDeletedTest < TestBase
   | shows diff_added_lines=0, diff_deleted_lines=0
   ) do
     in_tennis_kata do |id, files|
-      next_index = kata_file_create(id, index=1, files, 'newfile.txt')
+      next_index = kata_file_create(id, index=1, files, 'newfile.txt', laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index
@@ -104,7 +104,7 @@ class KataDiffAddedDeletedTest < TestBase
       deleted_lines = deleted_content.split("\n")
       assert deleted_lines.size > 0
 
-      next_index = kata_file_delete(id, index=1, files, 'readme.txt')
+      next_index = kata_file_delete(id, index=1, files, 'readme.txt', laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index
@@ -130,7 +130,7 @@ class KataDiffAddedDeletedTest < TestBase
       lines[4] = lines[4].rstrip + "Hello world"
 
       files['readme.txt']['content'] = lines.join("\n")
-      next_index = kata_file_edit(id, index=1, files)
+      next_index = kata_file_edit(id, index=1, files, laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index

--- a/test/server/kata_download.rb
+++ b/test/server/kata_download.rb
@@ -16,8 +16,8 @@ class KataDownloadTest < TestBase
     in_kata do |id|
       files = kata_event(id, 0)['files']
       expected_cyber_dojo_sh = files['cyber-dojo.sh']['content']
-      kata_ran_tests(id, 1, files, stdout, stderr,   '0', summary)
-      kata_ran_tests(id, 2, files, stdout, stderr,   '1', summary)
+      kata_ran_tests(id, 1, files, stdout, stderr,   '0', summary, laptop_id)
+      kata_ran_tests(id, 2, files, stdout, stderr,   '1', summary, laptop_id)
       year, month, day = 2021, 7, 11
       externals.instance_exec { @time = TimeStub.new([year, month, day]) }
       tgz_filename, encoded64 = *model.kata_download(id:id)
@@ -92,8 +92,8 @@ class KataDownloadTest < TestBase
     summary = { 'colour' => 'red' }
     in_kata do |id|
       files = kata_event(id, 0)['files']
-      kata_ran_tests(id, 1, files, stdout, stderr, '0', summary)
-      kata_ran_tests(id, 2, files, stdout, stderr, '1', summary)
+      kata_ran_tests(id, 1, files, stdout, stderr, '0', summary, laptop_id)
+      kata_ran_tests(id, 2, files, stdout, stderr, '1', summary, laptop_id)
 
       File.write(working_tree_path(id, 'events.json'), 'CORRUPT-NOT-JSON')
 

--- a/test/server/kata_event.rb
+++ b/test/server/kata_event.rb
@@ -133,7 +133,7 @@ class KataEventTest < TestBase
   ) do
     in_tennis_kata do |id, files|
       kata_event(id, -1)
-      kata_file_delete(id, index=1, files, 'readme.txt')
+      kata_file_delete(id, index=1, files, 'readme.txt', laptop_id)
       kata_event(id, -2)
       ex = assert_raises(RuntimeError) do
         kata_event(id, -3)

--- a/test/server/kata_events.rb
+++ b/test/server/kata_events.rb
@@ -67,16 +67,16 @@ class KataEventsTest < TestBase
     in_kata do |id|
       files = kata_event(id, 0)['files']
       
-      kata_file_create(id, 1, files, 'newfile.txt')
+      kata_file_create(id, 1, files, 'newfile.txt', laptop_id)
       
-      kata_ran_tests(id, 2, files, stdout, stderr,   '0', summary)
+      kata_ran_tests(id, 2, files, stdout, stderr,   '0', summary, laptop_id)
 
       files['newfile.txt'] = { 'content' => 'edited' }
-      kata_file_rename(id, 3, files, 'newfile.txt', 'newfile2.txt')
+      kata_file_rename(id, 3, files, 'newfile.txt', 'newfile2.txt', laptop_id)
 
-      kata_ran_tests(id, 5, files, stdout, stderr,   '0', summary)
+      kata_ran_tests(id, 5, files, stdout, stderr,   '0', summary, laptop_id)
       
-      kata_ran_tests(id, 6, files, stdout, stderr, '137', summary)
+      kata_ran_tests(id, 6, files, stdout, stderr, '137', summary, laptop_id)
 
       actual = kata_events(id)
       assert_equal 7, actual.size
@@ -151,7 +151,8 @@ class KataEventsTest < TestBase
       'time' => time,
       'colour' => colour,
       'diff_added_count' => diff_added_count,
-      'diff_deleted_count' => diff_deleted_count
+      'diff_deleted_count' => diff_deleted_count,
+      'laptop_id' => laptop_id
     }
   end
 
@@ -164,7 +165,8 @@ class KataEventsTest < TestBase
       'colour' => 'file_create',
       'filename' => filename,
       'diff_added_count' => 0,
-      'diff_deleted_count' => 0
+      'diff_deleted_count' => 0,
+      'laptop_id' => laptop_id
     }
   end
 
@@ -177,7 +179,8 @@ class KataEventsTest < TestBase
       'colour' => 'file_edit',
       'filename' => filename,
       'diff_added_count' => diff_added_count,
-      'diff_deleted_count' => diff_deleted_count
+      'diff_deleted_count' => diff_deleted_count,
+      'laptop_id' => laptop_id
     }
   end
 
@@ -191,7 +194,8 @@ class KataEventsTest < TestBase
       'old_filename' => old_filename,
       'new_filename' => new_filename,
       'diff_added_count' => 0,
-      'diff_deleted_count' => 0
+      'diff_deleted_count' => 0,
+      'laptop_id' => laptop_id
     }
   end
 

--- a/test/server/kata_file_create.rb
+++ b/test/server/kata_file_create.rb
@@ -16,9 +16,9 @@ class KataFileCreateTest < TestBase
   | with the created file having empty content
   ) do
     in_tennis_kata do |id, files, stdout, stderr, status|
-      kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary)
+      kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary, laptop_id)
 
-      next_index = kata_file_create(id, index=2, files, 'wibble.txt')
+      next_index = kata_file_create(id, index=2, files, 'wibble.txt', laptop_id)
 
       events = kata_events(id)
       assert_equal 3, next_index
@@ -45,13 +45,13 @@ class KataFileCreateTest < TestBase
   | the second for the newly created file
   ) do
     in_tennis_kata do |id, files, stdout, stderr, status|
-      kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary)
+      kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary, laptop_id)
 
       edited_content = files['readme.txt']['content'] + 'Hello world'
       files['readme.txt']['content'] = edited_content
 
       # VIP: at this point 'wibble.txt', the new filename, is NOT in files
-      next_index = kata_file_create(id, index=2, files, 'wibble.txt')
+      next_index = kata_file_create(id, index=2, files, 'wibble.txt', laptop_id)
 
       events = kata_events(id)
       assert_equal 4, next_index
@@ -84,7 +84,7 @@ class KataFileCreateTest < TestBase
     id = kids[version]
     files = kata_event(id, 0)['files']
     assert_raises(NoLongerImplementedError) do
-      kata_file_create(id, 1, files, 'wibble.txt')
+      kata_file_create(id, 1, files, 'wibble.txt', laptop_id)
     end
   end
 

--- a/test/server/kata_file_delete.rb
+++ b/test/server/kata_file_delete.rb
@@ -15,7 +15,7 @@ class KataFileDeleteTest < TestBase
   | results in a single delete-file event 
   ) do
     in_tennis_kata do |id, files|
-      next_index = kata_file_delete(id, index=1, files, 'readme.txt')
+      next_index = kata_file_delete(id, index=1, files, 'readme.txt', laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index
@@ -46,7 +46,7 @@ class KataFileDeleteTest < TestBase
       files['readme.txt']['content'] = edited_content
       
       # At this point, 'tennis.py', the deleted file, IS in files
-      next_index = kata_file_delete(id, index=1, files, 'tennis.py')
+      next_index = kata_file_delete(id, index=1, files, 'tennis.py', laptop_id)
 
       events = kata_events(id)
       assert_equal 3, next_index
@@ -83,7 +83,7 @@ class KataFileDeleteTest < TestBase
       edited_content = files['readme.txt']['content'] + 'Hello world'
       files['readme.txt']['content'] = edited_content
       
-      next_index = kata_file_delete(id, index=1, files, 'readme.txt')
+      next_index = kata_file_delete(id, index=1, files, 'readme.txt', laptop_id)
 
       events = kata_events(id)
       assert_equal 3, next_index
@@ -115,7 +115,7 @@ class KataFileDeleteTest < TestBase
     id = kids[version]
     files = kata_event(id, 0)['files']
     assert_raises(NoLongerImplementedError) do
-      kata_file_delete(id, 1, files, 'readme.txt')
+      kata_file_delete(id, 1, files, 'readme.txt', laptop_id)
     end
   end
 

--- a/test/server/kata_file_edit.rb
+++ b/test/server/kata_file_edit.rb
@@ -15,7 +15,7 @@ class KataFileEditTest < TestBase
   | does NOT create any new events
   ) do
     in_tennis_kata do |id, files|
-      next_index = kata_file_edit(id, index=1, files)
+      next_index = kata_file_edit(id, index=1, files, laptop_id)
 
       events = kata_events(id)
       assert_equal 1, next_index
@@ -38,7 +38,7 @@ class KataFileEditTest < TestBase
       edited_content = files['readme.txt']['content'] + 'Hello world'
       files['readme.txt']['content'] = edited_content
 
-      next_index = kata_file_edit(id, index=1, files)
+      next_index = kata_file_edit(id, index=1, files, laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index
@@ -63,7 +63,7 @@ class KataFileEditTest < TestBase
     id = kids[version]
     files = kata_event(id, 0)['files']
     assert_raises(NoLongerImplementedError) do
-      kata_file_edit(id, 1, files)
+      kata_file_edit(id, 1, files, laptop_id)
     end
   end
 end

--- a/test/server/kata_file_rename.rb
+++ b/test/server/kata_file_rename.rb
@@ -17,7 +17,7 @@ class KataFileRenameTest < TestBase
     in_tennis_kata do |id, files|
       content = files['readme.txt']['content']
       
-      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md')
+      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md', laptop_id)
 
       events = kata_events(id)
       assert_equal 2, next_index
@@ -51,7 +51,7 @@ class KataFileRenameTest < TestBase
       renamed_content = files['readme.txt']['content']
       files['tennis.py']['content'] = edited_content
       
-      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md')
+      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md', laptop_id)
 
       assert_equal 3, next_index
       events = kata_events(id)
@@ -90,7 +90,7 @@ class KataFileRenameTest < TestBase
       edited_content = files['readme.txt']['content'] + '# some comment'
       files['readme.txt']['content'] = edited_content
       
-      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md')
+      next_index = kata_file_rename(id, index=1, files, 'readme.txt', 'readme.md', laptop_id)
 
       events = kata_events(id)
       assert_equal 3, next_index
@@ -125,7 +125,7 @@ class KataFileRenameTest < TestBase
     id = kids[version]
     files = kata_event(id, 0)['files']
     assert_raises(NoLongerImplementedError) do
-      kata_file_rename(id, 1, files, 'readme.txt', 'readme2.txt')
+      kata_file_rename(id, 1, files, 'readme.txt', 'readme2.txt', laptop_id)
     end
   end
 

--- a/test/server/kata_fork.rb
+++ b/test/server/kata_fork.rb
@@ -48,7 +48,7 @@ class KataForkTest < TestBase
         "duration" => 1.46448,
         "predicted" => "none",
       }
-      kata_ran_tests(kid, index=1, files, stdout, stderr, status, red_summary)
+      kata_ran_tests(kid, index=1, files, stdout, stderr, status, red_summary, laptop_id)
 
       fid = kata_fork(kid, index)
 

--- a/test/server/kata_mobbing_detection.rb
+++ b/test/server/kata_mobbing_detection.rb
@@ -1,0 +1,113 @@
+require_relative 'test_base'
+
+class KataMobbingDetectionTest < TestBase
+
+  def initialize(arg)
+    super(arg)
+    @version = 2
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'Mb7D01', %w(
+  | a stale-index write whose only intervening event carries the requester's own
+  | laptop_id is accepted and appended at head+1: the solo lost-response case is
+  | self-lag, not mobbing, so no dialog fires.
+  ) do
+    id = kata_create(custom_manifest)
+    files = kata_event(id, 0)['files']
+    stdout = { 'content' => 'o', 'truncated' => false }
+    stderr = { 'content' => 'e', 'truncated' => false }
+
+    kata_ran_tests(id, 1, files, stdout, stderr, '0', red_summary, laptop_id)
+    kata_ran_tests(id, 2, files, stdout, stderr, '0', red_summary, laptop_id)
+
+    result = kata_ran_tests(id, 2, files, stdout, stderr, '0', red_summary, laptop_id)
+
+    assert_equal 4, result['next_index']
+    assert_equal 4, kata_events(id).size
+    assert_equal 3, kata_event(id, -1)['index']
+    assert_equal laptop_id, kata_event(id, -1)['laptop_id']
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'Mb7D02', %w(
+  | a reused index whose intervening event was written by a different laptop_id
+  | is rejected as out-of-order: two laptops genuinely interfering.
+  ) do
+    id = kata_create(custom_manifest)
+    files = kata_event(id, 0)['files']
+    stdout = { 'content' => 'o', 'truncated' => false }
+    stderr = { 'content' => 'e', 'truncated' => false }
+
+    kata_ran_tests(id, 1, files, stdout, stderr, '0', red_summary, laptop_id)
+
+    error = assert_raises(RuntimeError) {
+      kata_ran_tests(id, 1, files, stdout, stderr, '0', red_summary, another_laptop_id)
+    }
+    assert_equal "Out of order event for #{id}", error.message
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'Mb7D03', %w(
+  | a write whose index is beyond head+1 (ahead of the committed head) is
+  | rejected as out-of-order: the browser claims a position that does not exist.
+  ) do
+    id = kata_create(custom_manifest)
+    files = kata_event(id, 0)['files']
+    stdout = { 'content' => 'o', 'truncated' => false }
+    stderr = { 'content' => 'e', 'truncated' => false }
+
+    kata_ran_tests(id, 1, files, stdout, stderr, '0', red_summary, laptop_id)
+
+    error = assert_raises(RuntimeError) {
+      kata_ran_tests(id, 3, files, stdout, stderr, '0', red_summary, laptop_id)
+    }
+    assert_equal "Out of order event for #{id}", error.message
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'Mb7D04', %w(
+  | a new laptop rotating into a kata loads fresh (index == head+1) and its write
+  | is accepted with no dialog even though its laptop_id differs: the index .. head
+  | range is empty, so identity is never examined (legitimate handoff).
+  ) do
+    id = kata_create(custom_manifest)
+    files = kata_event(id, 0)['files']
+    stdout = { 'content' => 'o', 'truncated' => false }
+    stderr = { 'content' => 'e', 'truncated' => false }
+
+    kata_ran_tests(id, 1, files, stdout, stderr, '0', red_summary, laptop_id)
+    kata_ran_tests(id, 2, files, stdout, stderr, '0', red_summary, laptop_id)
+
+    result = kata_ran_tests(id, 3, files, stdout, stderr, '0', red_summary, another_laptop_id)
+
+    assert_equal 4, result['next_index']
+    assert_equal 4, kata_events(id).size
+    assert_equal 3, kata_event(id, -1)['index']
+    assert_equal another_laptop_id, kata_event(id, -1)['laptop_id']
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'Mb7D05', %w(
+  | with no laptop_id (the transitional path) a reused index is rejected as
+  | out-of-order by the index check; laptop_id detection does not apply.
+  ) do
+    id = kata_create(custom_manifest)
+    files = kata_event(id, 0)['files']
+    stdout = { 'content' => 'o', 'truncated' => false }
+    stderr = { 'content' => 'e', 'truncated' => false }
+
+    kata_ran_tests(id, 1, files, stdout, stderr, '0', red_summary, nil)
+
+    error = assert_raises(RuntimeError) {
+      kata_ran_tests(id, 1, files, stdout, stderr, '0', red_summary, nil)
+    }
+    assert_equal "Out of order event for #{id}", error.message
+  end
+
+end

--- a/test/server/kata_predicted_right.rb
+++ b/test/server/kata_predicted_right.rb
@@ -12,7 +12,7 @@ class KataPredictedRightTest < TestBase
       stderr = data['stderr']
       status = data['status']
       summary = red_summary.merge({ 'predicted' => 'red' })
-      kata_predicted_right(id, index=1, files, stdout, stderr, status, summary)
+      kata_predicted_right(id, index=1, files, stdout, stderr, status, summary, laptop_id)
       assert_tag_commit_message(id, 1, '1 ran tests, predicted red, got red')
       [index, summary]
     end
@@ -30,7 +30,7 @@ class KataPredictedRightTest < TestBase
     data = bats
     summary = red_summary.merge({ 'predicted' => 'red' })
     assert_raises(NoLongerImplementedError) do
-      kata_predicted_right(id, 1, files, data['stdout'], data['stderr'], data['status'], summary)
+      kata_predicted_right(id, 1, files, data['stdout'], data['stderr'], data['status'], summary, laptop_id)
     end
   end
 
@@ -48,11 +48,11 @@ class KataPredictedRightTest < TestBase
       files = kata_event(id, 0)['files']
 
       next_index = 1
-      next_index = kata_file_create(id, next_index, files, 'wibble1.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble1.txt', laptop_id)
       assert_equal 2, next_index
-      next_index = kata_file_create(id, next_index, files, 'wibble2.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble2.txt', laptop_id)
       assert_equal 3, next_index
-      next_index = kata_file_rename(id, next_index, files, 'wibble2.txt', 'wibble3.txt')
+      next_index = kata_file_rename(id, next_index, files, 'wibble2.txt', 'wibble3.txt', laptop_id)
       assert_equal 4, next_index
 
       edited_content = files['readme.txt']['content'] + 'Hello world'
@@ -62,19 +62,19 @@ class KataPredictedRightTest < TestBase
       stderr = data['stderr']
       status = data['status']
 
-      actual = kata_predicted_right(id, next_index, files, stdout, stderr, status, red_summary)
+      actual = kata_predicted_right(id, next_index, files, stdout, stderr, status, red_summary, laptop_id)
       expected = { 'next_index' => 6, 'major_index' => 1, 'minor_index' => 0 }
       assert_equal expected, actual
 
       next_index = expected['next_index']
-      next_index = kata_file_create(id, next_index, files, 'wibble3.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble3.txt', laptop_id)
       assert_equal 7, next_index
-      next_index = kata_file_create(id, next_index, files, 'wibble4.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble4.txt', laptop_id)
       assert_equal 8, next_index
-      next_index = kata_file_rename(id, next_index, files, 'wibble4.txt', 'wibble5.txt')
+      next_index = kata_file_rename(id, next_index, files, 'wibble4.txt', 'wibble5.txt', laptop_id)
       assert_equal 9, next_index
 
-      actual = kata_predicted_right(id, next_index, files, stdout, stderr, status, red_summary)
+      actual = kata_predicted_right(id, next_index, files, stdout, stderr, status, red_summary, laptop_id)
       expected = { 'next_index' => 10, 'major_index' => 2, 'minor_index' => 0 }
       assert_equal expected, actual
     end

--- a/test/server/kata_predicted_wrong.rb
+++ b/test/server/kata_predicted_wrong.rb
@@ -12,7 +12,7 @@ class KataPredictedWrongTest < TestBase
       stderr = data['stderr']
       status = data['status']
       summary = red_summary.merge({ 'predicted' => 'green' })
-      kata_predicted_wrong(id, index=1, files, stdout, stderr, status, summary)
+      kata_predicted_wrong(id, index=1, files, stdout, stderr, status, summary, laptop_id)
       assert_tag_commit_message(id, 1, '1 ran tests, predicted green, got red')
       [index, summary]
     end
@@ -30,7 +30,7 @@ class KataPredictedWrongTest < TestBase
     data = bats
     summary = red_summary.merge({ 'predicted' => 'green' })
     assert_raises(NoLongerImplementedError) do
-      kata_predicted_wrong(id, 1, files, data['stdout'], data['stderr'], data['status'], summary)
+      kata_predicted_wrong(id, 1, files, data['stdout'], data['stderr'], data['status'], summary, laptop_id)
     end
   end
 
@@ -48,11 +48,11 @@ class KataPredictedWrongTest < TestBase
       files = kata_event(id, 0)['files']
 
       next_index = 1
-      next_index = kata_file_create(id, next_index, files, 'wibble1.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble1.txt', laptop_id)
       assert_equal 2, next_index
-      next_index = kata_file_create(id, next_index, files, 'wibble2.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble2.txt', laptop_id)
       assert_equal 3, next_index
-      next_index = kata_file_rename(id, next_index, files, 'wibble2.txt', 'wibble3.txt')
+      next_index = kata_file_rename(id, next_index, files, 'wibble2.txt', 'wibble3.txt', laptop_id)
       assert_equal 4, next_index
 
       edited_content = files['readme.txt']['content'] + 'Hello world'
@@ -62,19 +62,19 @@ class KataPredictedWrongTest < TestBase
       stderr = data['stderr']
       status = data['status']
 
-      actual = kata_predicted_wrong(id, next_index, files, stdout, stderr, status, red_summary)
+      actual = kata_predicted_wrong(id, next_index, files, stdout, stderr, status, red_summary, laptop_id)
       expected = { 'next_index' => 6, 'major_index' => 1, 'minor_index' => 0 }
       assert_equal expected, actual
 
       next_index = expected['next_index']
-      next_index = kata_file_create(id, next_index, files, 'wibble3.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble3.txt', laptop_id)
       assert_equal 7, next_index
-      next_index = kata_file_create(id, next_index, files, 'wibble4.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble4.txt', laptop_id)
       assert_equal 8, next_index
-      next_index = kata_file_rename(id, next_index, files, 'wibble4.txt', 'wibble5.txt')
+      next_index = kata_file_rename(id, next_index, files, 'wibble4.txt', 'wibble5.txt', laptop_id)
       assert_equal 9, next_index
 
-      actual = kata_predicted_wrong(id, next_index, files, stdout, stderr, status, red_summary)
+      actual = kata_predicted_wrong(id, next_index, files, stdout, stderr, status, red_summary, laptop_id)
       expected = { 'next_index' => 10, 'major_index' => 2, 'minor_index' => 0 }
       assert_equal expected, actual
     end

--- a/test/server/kata_ran_tests.rb
+++ b/test/server/kata_ran_tests.rb
@@ -6,7 +6,7 @@ class KataRanTestsTest < TestBase
   | kata_ran_tests stores a ran-tests event with correct commit message
   ) do
     in_kata do |id, files, stdout, stderr, status|
-      kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary)
+      kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary, laptop_id)
       assert_tag_commit_message(id, 1, '1 ran tests, no prediction, got red')
       [index, red_summary]
     end
@@ -18,25 +18,9 @@ class KataRanTestsTest < TestBase
   | kata_ran_tests returns next_index incremented by 1
   ) do
     in_kata do |id, files, stdout, stderr, status|
-      result = kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary)
+      result = kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary, laptop_id)
       next_index = result['next_index']
       assert_equal 2, next_index
-      [index=1, red_summary]
-    end
-  end
-
-  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-  version_test 2, 'Sp4Dk9', %w(
-  | kata_ran_tests with an already used index
-  | raises "Out of order event" exception
-  ) do
-    in_kata do |id, files, stdout, stderr, status|
-      kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary)
-      error = assert_raises(RuntimeError) {
-        kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary)
-      }
-      assert_equal "Out of order event for #{id}", error.message
       [index=1, red_summary]
     end
   end
@@ -68,7 +52,7 @@ class KataRanTestsTest < TestBase
     externals.instance_variable_set('@shell', error_shell)
 
     error = assert_raises(RuntimeError) {
-      kata_ran_tests(id, 1, files, stdout, stderr, status, red_summary)
+      kata_ran_tests(id, 1, files, stdout, stderr, status, red_summary, laptop_id)
     }
     assert_equal 'simulated update-ref failure', error.message
   end
@@ -92,7 +76,7 @@ class KataRanTestsTest < TestBase
     status = 0
 
     # First save succeeds: events.json gains index 1 and tag 1 is written.
-    kata_ran_tests(id, 1, files, stdout, stderr, status, red_summary)
+    kata_ran_tests(id, 1, files, stdout, stderr, status, red_summary, laptop_id)
 
     # Wrap the in-process git so the next tag read reproduces the window: the
     # first tag_tree_blobs raises TagNotFound (tag momentarily absent), then the
@@ -120,7 +104,7 @@ class KataRanTestsTest < TestBase
 
     # The losing concurrent save (same index 1) must report out-of-order.
     error = assert_raises(RuntimeError) {
-      kata_ran_tests(id, 1, files, stdout, stderr, status, red_summary)
+      kata_ran_tests(id, 1, files, stdout, stderr, status, red_summary, laptop_id)
     }
     assert_equal "Out of order event for #{id}", error.message
     # Confirm the window was actually reproduced: a stale save reports
@@ -200,7 +184,7 @@ class KataRanTestsTest < TestBase
     files = kata_event(id, 0)['files']
     data = bats
     assert_raises(NoLongerImplementedError) do
-      kata_ran_tests(id, 1, files, data['stdout'], data['stderr'], data['status'], red_summary)
+      kata_ran_tests(id, 1, files, data['stdout'], data['stderr'], data['status'], red_summary, laptop_id)
     end
   end
 
@@ -212,7 +196,7 @@ class KataRanTestsTest < TestBase
     files = kata_event(id, 0)['files']
     data = bats
     assert_raises(NoLongerImplementedError) do
-      kata_ran_tests(id, 1, files, data['stdout'], data['stderr'], data['status'], red_summary)
+      kata_ran_tests(id, 1, files, data['stdout'], data['stderr'], data['status'], red_summary, laptop_id)
     end
   end
 
@@ -232,7 +216,7 @@ class KataRanTestsTest < TestBase
     path   = working_tree_path(id, 'events.json')
     before = File.read(path)
 
-    kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary)
+    kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary, laptop_id)
 
     # correctness: the committed state advanced (read via git)
     assert_equal 2, kata_events(id).size

--- a/test/server/kata_ran_tests_with_edit.rb
+++ b/test/server/kata_ran_tests_with_edit.rb
@@ -14,11 +14,11 @@ class KataRanTestsWithEditTest < TestBase
       files = kata_event(id, 0)['files']
 
       next_index = 1
-      next_index = kata_file_create(id, next_index, files, 'wibble1.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble1.txt', laptop_id)
       assert_equal 2, next_index
-      next_index = kata_file_create(id, next_index, files, 'wibble2.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble2.txt', laptop_id)
       assert_equal 3, next_index
-      next_index = kata_file_rename(id, next_index, files, 'wibble2.txt', 'wibble3.txt')
+      next_index = kata_file_rename(id, next_index, files, 'wibble2.txt', 'wibble3.txt', laptop_id)
       assert_equal 4, next_index
 
       edited_content = files['readme.txt']['content'] + 'Hello world'
@@ -28,19 +28,19 @@ class KataRanTestsWithEditTest < TestBase
       stderr = data['stderr']
       status = data['status']
 
-      actual = kata_ran_tests(id, next_index, files, stdout, stderr, status, red_summary)
+      actual = kata_ran_tests(id, next_index, files, stdout, stderr, status, red_summary, laptop_id)
       expected = { 'next_index' => 6, 'major_index' => 1, 'minor_index' => 0 }
       assert_equal expected, actual
 
       next_index = expected['next_index']
-      next_index = kata_file_create(id, next_index, files, 'wibble3.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble3.txt', laptop_id)
       assert_equal 7, next_index
-      next_index = kata_file_create(id, next_index, files, 'wibble4.txt')
+      next_index = kata_file_create(id, next_index, files, 'wibble4.txt', laptop_id)
       assert_equal 8, next_index
-      next_index = kata_file_rename(id, next_index, files, 'wibble4.txt', 'wibble5.txt')
+      next_index = kata_file_rename(id, next_index, files, 'wibble4.txt', 'wibble5.txt', laptop_id)
       assert_equal 9, next_index
 
-      actual = kata_ran_tests(id, next_index, files, stdout, stderr, status, red_summary)
+      actual = kata_ran_tests(id, next_index, files, stdout, stderr, status, red_summary, laptop_id)
       expected = { 'next_index' => 10, 'major_index' => 2, 'minor_index' => 0 }
       assert_equal expected, actual
     end

--- a/test/server/kata_ran_tests_with_outage.rb
+++ b/test/server/kata_ran_tests_with_outage.rb
@@ -21,7 +21,7 @@ class KataRanTestsWithOutageTest < TestBase
       files.delete('readme.txt')
       next_index = 1
 
-      actual = kata_ran_tests(id, next_index, files, stdout, stderr, status, red_summary)
+      actual = kata_ran_tests(id, next_index, files, stdout, stderr, status, red_summary, laptop_id)
       expected = { 'next_index' => 2, 'major_index' => 1, 'minor_index' => 0 }
       assert_equal expected, actual
     end

--- a/test/server/kata_reverted.rb
+++ b/test/server/kata_reverted.rb
@@ -12,13 +12,13 @@ class KataRevertedTest < TestBase
       stderr = data['stderr']
       status = data['status']
 
-      kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary)
-      kata_ran_tests(id, index=2, files, stdout, stderr, status, red_summary)
+      kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary, laptop_id)
+      kata_ran_tests(id, index=2, files, stdout, stderr, status, red_summary, laptop_id)
       reverted_summary = { 
         'colour' => 'red', 
         'revert' => [id, index=1] 
       }
-      kata_reverted(id, index=3, files, stdout, stderr, status, reverted_summary)
+      kata_reverted(id, index=3, files, stdout, stderr, status, reverted_summary, laptop_id)
       expected = JSON.generate({'id': id, 'index': 1})
       assert_tag_commit_message(id, 3, "3 reverted to #{expected}")
       [index, reverted_summary]
@@ -37,14 +37,14 @@ class KataRevertedTest < TestBase
       stderr = data['stderr']
       status = data['status']
 
-      kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary)
-      kata_ran_tests(id, index=2, files, stdout, stderr, status, red_summary)
+      kata_ran_tests(id, index=1, files, stdout, stderr, status, red_summary, laptop_id)
+      kata_ran_tests(id, index=2, files, stdout, stderr, status, red_summary, laptop_id)
       reverted_summary = { 
         'colour' => 'red', 
         'revert' => [id, index=1] 
       }
 
-      result = kata_reverted(id, index=3, files, stdout, stderr, status, reverted_summary)
+      result = kata_reverted(id, index=3, files, stdout, stderr, status, reverted_summary, laptop_id)
       next_index = result['next_index']
 
       actual = kata_event(id, next_index - 1)
@@ -70,7 +70,7 @@ class KataRevertedTest < TestBase
     data = bats
     reverted_summary = { 'colour' => 'red', 'revert' => [id, 0] }
     assert_raises(NoLongerImplementedError) do
-      kata_reverted(id, 1, files, data['stdout'], data['stderr'], data['status'], reverted_summary)
+      kata_reverted(id, 1, files, data['stdout'], data['stderr'], data['status'], reverted_summary, laptop_id)
     end
   end
 

--- a/test/server/kata_stores_laptop_id.rb
+++ b/test/server/kata_stores_laptop_id.rb
@@ -1,0 +1,102 @@
+require_relative 'test_base'
+
+class KataStoresLaptopIdTest < TestBase
+
+  def initialize(arg)
+    super(arg)
+    @version = 2
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'La3F01', %w(
+  | a kata_file_create stores the writer's laptop_id on the committed event
+  ) do
+    id = kata_create(custom_manifest)
+    files = kata_event(id, 0)['files']
+    model.kata_file_create(id: id, index: 1, files: files, filename: 'wibble.txt', laptop_id: LAPTOP_A)
+    event = kata_event(id, 1)
+    assert_equal 'file_create', event['colour']
+    assert_equal LAPTOP_A, event['laptop_id']
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'La3F02', %w(
+  | a write that also commits an implicit file_edit stamps BOTH events
+  | (the edit and the create) with the same laptop_id
+  ) do
+    id = kata_create(custom_manifest)
+    files = kata_event(id, 0)['files']
+    edited = files.keys.first
+    files[edited]['content'] += "\n# edited"
+    model.kata_file_create(id: id, index: 1, files: files, filename: 'wibble.txt', laptop_id: LAPTOP_B)
+    events = kata_events(id)
+    assert_equal 3, events.size
+    assert_equal 'file_edit',   kata_event(id, 1)['colour']
+    assert_equal 'file_create', kata_event(id, 2)['colour']
+    assert_equal LAPTOP_B, kata_event(id, 1)['laptop_id']
+    assert_equal LAPTOP_B, kata_event(id, 2)['laptop_id']
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'La3F03', %w(
+  | a kata_ran_tests stores the writer's laptop_id on the committed event
+  ) do
+    id = kata_create(custom_manifest)
+    files = kata_event(id, 0)['files']
+    stdout = { 'content' => 'o', 'truncated' => false }
+    stderr = { 'content' => 'e', 'truncated' => false }
+    model.kata_ran_tests(id: id, index: 1, files: files, stdout: stdout, stderr: stderr, status: '0', summary: red_summary, laptop_id: LAPTOP_C)
+    assert_equal LAPTOP_C, kata_event(id, 1)['laptop_id']
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'La3F04', %w(
+  | a write with no laptop_id (nil from the outside) does NOT store a
+  | laptop_id key on the event at all, leaving it indistinguishable from a
+  | legacy pre-laptop_id event; the other event fields are unchanged
+  ) do
+    id = kata_create(custom_manifest)
+    files = kata_event(id, 0)['files']
+    model.kata_file_create(id: id, index: 1, files: files, filename: 'wibble.txt')
+    event = kata_event(id, 1)
+    refute event.key?('laptop_id'), event.to_json
+    assert_equal 'file_create', event['colour']
+    assert_equal 'wibble.txt', event['filename']
+    assert_equal 1, event['index']
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'La3F05', %w(
+  | a write whose laptop_id is not the minted format (64 lowercase hex chars)
+  | is NOT stored - only a well-formed id is trusted; a malformed one is
+  | treated like an absent id (no laptop_id key on the event)
+  ) do
+    [
+      'not-hex-at-all',
+      'abc123',        # too short
+      'A' * 64,        # uppercase, not lowercase hex
+      'g' * 64,        # non-hex letters
+      '0' * 63,        # 63 chars
+      '0' * 65         # 65 chars
+    ].each do |bad|
+      id = kata_create(custom_manifest)
+      files = kata_event(id, 0)['files']
+      model.kata_file_create(id: id, index: 1, files: files, filename: 'wibble.txt', laptop_id: bad)
+      event = kata_event(id, 1)
+      refute event.key?('laptop_id'), "stored bad laptop_id #{bad.inspect}: #{event.to_json}"
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  # Realistic laptop_ids: SecureRandom.hex(32), as minted by the web before-hook.
+  LAPTOP_A = '02cfdffb5c0c31221b837a153d1108e6cd19fd6cef11db27c8457a1e63caf46f'
+  LAPTOP_B = 'ca990e850c196480e16b8f04a611297e12ea64c93766055643e0e60f8f8d51e0'
+  LAPTOP_C = '37ef5ee71537279bb25b3040ba6616b5e97a7351f12ce659d798fa2841813324'
+
+end

--- a/test/server/kata_torn_read.rb
+++ b/test/server/kata_torn_read.rb
@@ -13,7 +13,7 @@ class KataTornReadTest < TestBase
       files  = kata_event(id, 0)['files']
       stdout = { 'content' => '', 'truncated' => false }
       stderr = { 'content' => '', 'truncated' => false }
-      kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary)
+      kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary, laptop_id)
 
       expected = kata_events(id)
 
@@ -38,7 +38,7 @@ class KataTornReadTest < TestBase
       files  = kata_event(id, 0)['files']
       stdout = { 'content' => '', 'truncated' => false }
       stderr = { 'content' => '', 'truncated' => false }
-      kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary)
+      kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary, laptop_id)
 
       expected = kata_events(id)
 
@@ -91,20 +91,20 @@ class KataTornReadTest < TestBase
   | committed events.json through git, not the working tree. The working tree is
   | stale (saves no longer refresh it), so reading it directly could mask the
   | out-of-order with a raw JSON/IO error. With a truncated working-tree
-  | events.json, a stale save still reports "Out of order event".
+  | events.json, a different-laptop stale save still reports "Out of order event".
   ) do
     in_kata do |id|
       files  = kata_event(id, 0)['files']
       stdout = { 'content' => '', 'truncated' => false }
       stderr = { 'content' => '', 'truncated' => false }
-      kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary)
+      kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary, laptop_id)
 
       path = working_tree_path(id, 'events.json')
       full = File.read(path)
       File.write(path, full[0, full.size / 2])
 
       error = assert_raises(RuntimeError) {
-        kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary)
+        kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary, another_laptop_id)
       }
       assert_equal "Out of order event for #{id}", error.message
     end
@@ -121,12 +121,12 @@ class KataTornReadTest < TestBase
       files  = kata_event(id, 0)['files']
       stdout = { 'content' => '', 'truncated' => false }
       stderr = { 'content' => '', 'truncated' => false }
-      kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary)
+      kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary, laptop_id)
 
       File.delete(working_tree_path(id, 'events.json'))
 
       error = assert_raises(RuntimeError) {
-        kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary)
+        kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary, another_laptop_id)
       }
       assert_equal "Out of order event for #{id}", error.message
     end
@@ -145,7 +145,7 @@ class KataTornReadTest < TestBase
       files  = kata_event(id, 0)['files']
       stdout = { 'content' => '', 'truncated' => false }
       stderr = { 'content' => '', 'truncated' => false }
-      kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary)
+      kata_ran_tests(id, 1, files, stdout, stderr, 0, red_summary, laptop_id)
 
       expected = kata_events(id)
 
@@ -201,7 +201,7 @@ class KataTornReadTest < TestBase
 
       # Grow events.json first so each later save rewrites it across more
       # write() chunks, widening the torn-read window.
-      40.times { |i| kata_ran_tests(id, i + 1, files, stdout, stderr, 0, red_summary) }
+      40.times { |i| kata_ran_tests(id, i + 1, files, stdout, stderr, 0, red_summary, laptop_id) }
       next_index = 41
 
       stop        = false
@@ -225,7 +225,7 @@ class KataTornReadTest < TestBase
       # Single writer: sequential saves keep git merge --ff-only continuously
       # rewriting the working-tree events.json that the readers are reading.
       150.times do
-        kata_ran_tests(id, next_index, files, stdout, stderr, 0, red_summary)
+        kata_ran_tests(id, next_index, files, stdout, stderr, 0, red_summary, laptop_id)
         next_index += 1
       end
 

--- a/test/server/kata_write_accepts_laptop_id.rb
+++ b/test/server/kata_write_accepts_laptop_id.rb
@@ -1,0 +1,61 @@
+require_relative 'test_base'
+
+class KataWriteAcceptsLaptopIdTest < TestBase
+
+  def initialize(arg)
+    super(arg)
+    @version = 2
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'Ac1B7a', %w(
+  | a kata_file_create POST carrying an extra laptop_id field is accepted
+  | (HTTP 200), not rejected by the strict-keyword dispatch as an unknown
+  | keyword. The saver tolerates the field, and does nothing with it, so web
+  | can start sending it before the saver stores it.
+  ) do
+    id = kata_create(custom_manifest)
+    files = kata_event(id, 0)['files']
+    body = {
+      id: id,
+      index: 1,
+      files: files,
+      filename: 'wibble.txt',
+      laptop_id: 'a1b2c3d4e5f6'
+    }.to_json
+
+    assert_json_post_200('kata_file_create', body) do |response|
+      assert_equal 2, response['kata_file_create']
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  test 'Ac1B7b', %w(
+  | a kata_ran_tests POST carrying an extra laptop_id field is accepted
+  | (HTTP 200), covering the stdout/stderr/status/summary write shape as
+  | well as the filename write shape.
+  ) do
+    id = kata_create(custom_manifest)
+    files = kata_event(id, 0)['files']
+    stdout = { 'content' => 'some-stdout', 'truncated' => false }
+    stderr = { 'content' => 'some-stderr', 'truncated' => false }
+    status = '0'
+    body = {
+      id: id,
+      index: 1,
+      files: files,
+      stdout: stdout,
+      stderr: stderr,
+      status: status,
+      summary: red_summary,
+      laptop_id: 'a1b2c3d4e5f6'
+    }.to_json
+
+    assert_json_post_200('kata_ran_tests', body) do |response|
+      assert_equal 2, response['kata_ran_tests']['next_index']
+    end
+  end
+
+end

--- a/test/server/katas_events.rb
+++ b/test/server/katas_events.rb
@@ -44,14 +44,14 @@ class KatasEventsTest < TestBase
       in_kata(gid) do |id|
         files = kata_event(id, 0)['files']
         ids << id
-        kata_ran_tests(id, 1, files, stdout, stderr, "0", red_summary)
+        kata_ran_tests(id, 1, files, stdout, stderr, "0", red_summary, laptop_id)
       end
       in_kata(gid) do |id|
         files = kata_event(id, 0)['files']
         ids << id
-        kata_ran_tests(id, 1, files, stdout, stderr,   '0', red_summary)
-        kata_ran_tests(id, 2, files, stdout, stderr,   '0', red_summary)
-        kata_ran_tests(id, 3, files, stdout, stderr, '137', red_summary)
+        kata_ran_tests(id, 1, files, stdout, stderr,   '0', red_summary, laptop_id)
+        kata_ran_tests(id, 2, files, stdout, stderr,   '0', red_summary, laptop_id)
+        kata_ran_tests(id, 3, files, stdout, stderr, '137', red_summary, laptop_id)
       end
       actual = katas_events([ids[0], ids[1]], [1, 3])
       expected = {
@@ -64,8 +64,9 @@ class KatasEventsTest < TestBase
             'stdout' => stdout,
             'stderr' => stderr,
             'status' => '0',
-            'diff_added_count' => 0, 
-            'diff_deleted_count' => 0
+            'diff_added_count' => 0,
+            'diff_deleted_count' => 0,
+            'laptop_id' => laptop_id
           }
         },
         ids[1] => {
@@ -77,8 +78,9 @@ class KatasEventsTest < TestBase
             'stdout' => stdout,
             'stderr' => stderr,
             'status' => '137',
-            'diff_added_count' => 0, 
-            'diff_deleted_count' => 0
+            'diff_added_count' => 0,
+            'diff_deleted_count' => 0,
+            'laptop_id' => laptop_id
           }
         }
       }

--- a/test/server/test_base.rb
+++ b/test/server/test_base.rb
@@ -77,6 +77,19 @@ class TestBase < Id58TestBase
     yield(id, kata_event(id, 0)['files'], stdout, stderr, status)
   end
 
+  # An arbitrary well-formed laptop_id (SecureRandom.hex(32) format), passed
+  # explicitly by tests on every event-write as a real client now does. Its
+  # specific value is not significant.
+  def laptop_id
+    '9b1c7f0e4a2d6538c1e0fb94a7d213e6f5028b4c9de71a36085fc2b7d419e0a2'
+  end
+
+  # A second well-formed laptop_id, distinct from laptop_id, for tests that need
+  # two different laptops (genuine mobbing).
+  def another_laptop_id
+    'ca990e850c196480e16b8f04a611297e12ea64c93766055643e0e60f8f8d51e0'
+  end
+
   def assert_tag_commit_message(id, tag, expected)
     dir = "/#{disk.root_dir}/katas/#{id[0..1]}/#{id[2..3]}/#{id[4..5]}"
     stdout = shell.assert_cd_exec(dir, "git tag --list --format='%(contents)' #{tag}")


### PR DESCRIPTION
  The "mobbing?" dialog should fire only when two laptops sharing a kata
  interfere. A solo user could trigger it: the browser owns its next-event
  index and advances it only from a successful response, so a lost or aborted
  inter-test response (whose event the saver still committed) leaves the
  browser's index behind the committed head. The next [test] then sent that
  stale index, and the saver's only mobbing signal was an index mismatch, so
  it rejected the write as "Out of order event" and the browser rendered a
  false dialog. A solo self-lag and genuine two-laptop interference were
  indistinguishable.

  Stamp each committed event with the id of the laptop that wrote it, so the
  saver can tell them apart. commit_event now runs dual-mode:
  - laptop_id present: placement is server-authoritative (head + 1); an index ahead of that is rejected; a behind index is accepted when every event the browser missed (index..head) was written by this same laptop (self-lag), and rejected only when a different laptop's write is in that range (genuine mobbing).
  - laptop_id absent (legacy events, or a client not yet sending one): today's index check is unchanged.

  laptop_id is an optional keyword on the event-write methods, stored only when
  it is the well-formed minted format (64-char lowercase hex); a nil, absent, or
  malformed value stores no key, so such events are indistinguishable from
  pre-laptop_id ones. git_commit_tag_sss now derives next_index from the
  committed head, so an accepted stale (self-lag) write reports the real index.

  Deploy safety: additive and only ever more-permissive. With no laptop_id the
  behaviour is byte-identical to today, so this must ship before web starts
  sending the field (the strict-kwarg dispatch would otherwise 500 on the
  unknown key). No write that succeeds today fails after this.

  Tests: kata_write_accepts_laptop_id, kata_stores_laptop_id,
  kata_mobbing_detection (self-lag accept, genuine-mobbing reject, ahead reject,
  handoff accept, nil-path reject), and end-to-end kata_laptop_id_test.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>