### PR TITLE
Exclude the unreachable racing_git respond_to_missing? from coverage

### DIFF
--- a/test/server/config/coverage_metrics_limits.rb
+++ b/test/server/config/coverage_metrics_limits.rb
@@ -3,7 +3,7 @@ def metrics
   [
     [ nil ],
     [ 'test.lines.total'    , '<=', 3178 ],
-    [ 'test.lines.missed'   , '<=', 1    ],
+    [ 'test.lines.missed'   , '<=', 0    ],
     [ 'test.branches.total' , '<=', 6    ],
     [ 'test.branches.missed', '<=', 0    ],
     [ nil ],

--- a/test/server/kata_ran_tests.rb
+++ b/test/server/kata_ran_tests.rb
@@ -282,7 +282,11 @@ class KataRanTestsTest < TestBase
         @real.public_send(name, *args, &block)
       end
       def respond_to_missing?(name, include_private = false)
+        # Never exercised: the model calls commit_on_main and the delegated methods
+        # on the double, never respond_to? - so this line is excluded from coverage.
+        # :nocov:
         @real.respond_to?(name, include_private)
+        # :nocov:
       end
     end.new(real, on_first_commit)
   end


### PR DESCRIPTION
  The racing_git test double delegates everything via method_missing; its
  respond_to_missing? body is never executed, because the tests only call
  commit_on_main and delegated methods on the double, never respond_to?. Mark that
  line # :nocov: so test.lines.missed returns to 0, and tighten the limit back from
  <= 1 to == 0.

  code.branches.missed stays at <= 1: the untested re-raise path in
  file_edit_before_test_event (a non-"Out of order" internal file_edit error must
  propagate) is still deferred to its own test - see the deferred-coverage note.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>