### PR TITLE
Make exit_non_zero actually exit

### DIFF
--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -16,7 +16,7 @@ exit_non_zero_unless_file_exists()
 
 exit_non_zero()
 {
-  kill -INT $$
+  exit 42
 }
 
 containers_down()


### PR DESCRIPTION
  kill -INT $$ only stops the script while nothing traps INT. Add
  a cleanup trap on INT - a normal thing for a script to do - and
  bash runs the handler and resumes at the next statement, so a
  guard prints its error and the script carries on to exit 0.
  exit 42 cannot be declined, and the EXIT trap still cleans up.