### PR TITLE
Use the simplecov 1.x spellings, and catch the client base image up

### DIFF
--- a/source/client/Dockerfile
+++ b/source/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cyber-dojo/sinatra-base:28b632a@sha256:41f5d307193f8c917082ee23443cf4fdf0b17af249522e0495030a413c8b9bcd
+FROM ghcr.io/cyber-dojo/sinatra-base:5ab6a10@sha256:c096154011cc1cef9cc69e8be948fb4329543f9670d4fb4fd3851a8aa016630d
 LABEL maintainer=jon@jaggersoft.com
 
 ARG COMMIT_SHA

--- a/source/server/lib/json_adapter.rb
+++ b/source/server/lib/json_adapter.rb
@@ -2,12 +2,12 @@ require 'json'
 
 module JsonAdapter
 
-  # :nocov:
+  # simplecov:disable
   def json_plain(obj)
     #Oj.dump(obj, { :mode => :strict })
     JSON.generate(obj)
   end
-  # :nocov:
+  # simplecov:enable
 
   def json_pretty(obj)
     #Oj.generate(obj, OJ_PRETTY_OPTIONS)

--- a/test/client/config/coverage.rb
+++ b/test/client/config/coverage.rb
@@ -8,18 +8,18 @@ SimpleCov.start do
   enable_coverage(:branch)
   primary_coverage(:branch)
   filters.clear
-  add_filter("test/id58_test_base.rb")
+  skip("test/id58_test_base.rb")
   root(APP_DIR)
 
   code_tab = ENV['COVERAGE_CODE_TAB_NAME']
   test_tab = ENV['COVERAGE_TEST_TAB_NAME']
-  # add_group('debug') { |the| puts(the.filename); false }
-  add_group(code_tab) { |the| the.filename.start_with?("#{APP_DIR}/source/") }
-  add_group(test_tab) { |the| the.filename.start_with?("#{APP_DIR}/test/") }
+  # group('debug') { |path| puts(path.filename); false }
+  group(code_tab) { |path| path.filename.start_with?("#{APP_DIR}/source/") }
+  group(test_tab) { |path| path.filename.start_with?("#{APP_DIR}/test/") }
 end
 
 formatters = [
   SimpleCov::Formatter::HTMLFormatter,
-  SimpleCov::Formatter::JSONFormatter,
+  CoverageMetricsFormatter,
 ]
 SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)

--- a/test/client/config/simplecov_formatter_json.rb
+++ b/test/client/config/simplecov_formatter_json.rb
@@ -1,8 +1,14 @@
 require 'simplecov'
 require 'json'
 
-class SimpleCov::Formatter::JSONFormatter
-  # based on https://github.com/vicentllongo/simplecov-json
+# A SimpleCov formatter writing coverage_metrics.json, which check_metrics
+# reads. SimpleCov ships its own JSON formatter, shaped per file rather than
+# per group, so this one carries its own name rather than reopening that class
+# and redefining its format method. Redefining it makes ruby -w report the
+# redefinition.
+#
+# based on https://github.com/vicentllongo/simplecov-json
+class CoverageMetricsFormatter
 
   def format(result)
     data = {

--- a/test/server/config/coverage.rb
+++ b/test/server/config/coverage.rb
@@ -8,18 +8,18 @@ SimpleCov.start do
   enable_coverage(:branch)
   primary_coverage(:branch)
   filters.clear
-  add_filter("test/id58_test_base.rb")
+  skip("test/id58_test_base.rb")
   root(APP_DIR)
 
   code_tab = ENV['COVERAGE_CODE_TAB_NAME']
   test_tab = ENV['COVERAGE_TEST_TAB_NAME']
-  # add_group('debug') { |the| puts(the.filename); false }
-  add_group(code_tab) { |the| the.filename.start_with?("#{APP_DIR}/source/") }
-  add_group(test_tab) { |the| the.filename.start_with?("#{APP_DIR}/test/") }
+  # group('debug') { |path| puts(path.filename); false }
+  group(code_tab) { |path| path.filename.start_with?("#{APP_DIR}/source/") }
+  group(test_tab) { |path| path.filename.start_with?("#{APP_DIR}/test/") }
 end
 
 formatters = [
   SimpleCov::Formatter::HTMLFormatter,
-  SimpleCov::Formatter::JSONFormatter,
+  CoverageMetricsFormatter,
 ]
 SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)

--- a/test/server/config/simplecov_formatter_json.rb
+++ b/test/server/config/simplecov_formatter_json.rb
@@ -1,8 +1,14 @@
 require 'simplecov'
 require 'json'
 
-class SimpleCov::Formatter::JSONFormatter
-  # based on https://github.com/vicentllongo/simplecov-json
+# A SimpleCov formatter writing coverage_metrics.json, which check_metrics
+# reads. SimpleCov ships its own JSON formatter, shaped per file rather than
+# per group, so this one carries its own name rather than reopening that class
+# and redefining its format method. Redefining it makes ruby -w report the
+# redefinition.
+#
+# based on https://github.com/vicentllongo/simplecov-json
+class CoverageMetricsFormatter
 
   def format(result)
     data = {

--- a/test/server/helpers/rack.rb
+++ b/test/server/helpers/rack.rb
@@ -57,13 +57,13 @@ module TestHelpersRack
 
   def assert_status(expected, stdout, stderr)
     actual = last_response.status
-    # :nocov:
+    # simplecov:disable
     if expected != actual
       print("stdout:\n#{stdout}")
       print("stderr:\n#{stderr}")
       assert_equal expected, actual
     end
-    # :nocov:
+    # simplecov:enable
   end
 
   def json_response_body

--- a/test/server/kata_ran_tests.rb
+++ b/test/server/kata_ran_tests.rb
@@ -99,9 +99,9 @@ class KataRanTestsTest < TestBase
       def respond_to_missing?(name, include_private = false)
         # Never exercised: the model calls tag_tree_blobs and the delegated methods
         # on the double, never respond_to? - so this line is excluded from coverage.
-        # :nocov:
+        # simplecov:disable
         @real.respond_to?(name, include_private)
-        # :nocov:
+        # simplecov:enable
       end
     end.new(git)
 


### PR DESCRIPTION
  The base image now carries simplecov 1.1.1 where it carried 0.21.2.
  Four spellings are deprecated there, each announcing itself on stderr on
  every run:

    add_group  -> group
    add_filter -> skip
    # :nocov:  -> # simplecov:disable / # simplecov:enable

  and the formatter reopened SimpleCov::Formatter::JSONFormatter to
  redefine format, which in 1.1.1 makes ruby -w report the redefinition.
  It is now CoverageMetricsFormatter, named for the coverage_metrics.json
  it writes. It never needed to be that class: what it produces is
  per-group totals, not the per-file shape the shipped formatter writes,
  so it was only borrowing the name to make itself win.

  source/client/Dockerfile was still pinned to sinatra-base:28b632a. The
  automated base-image PR only rewrites the Dockerfile at the repo root,
  so the client image had been drifting behind, and would have met these
  spellings on the older simplecov and failed. Both Dockerfiles now name
  the same image.

  Two of the :nocov: pairs are in tests and one is in source, guarding
  json_plain, which nothing calls.

  The group block parameter goes from the to path while passing, matching
  the other repos and saying what it is.

  Coverage is unchanged either side: server test 3187 / code 1621, client
  test 1007 / code 142, nothing missed in any of them.